### PR TITLE
fix(blog): enable SSG prerendering for blog dynamic routes

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,6 +2,8 @@
 import { getCollection, getEntry, render } from "astro:content";
 import PageLayout from "@/layouts/PageLayout.astro";
 
+export const prerender = true;
+
 // Generate static paths for all blog posts
 export async function getStaticPaths() {
     const posts = await getCollection("blog");


### PR DESCRIPTION
## Summary

Add `export const prerender = true` to `blog/[...slug].astro` so `getStaticPaths()` correctly generates static HTML at build time, instead of being silently ignored under SSR mode.

## Changes

- Added `export const prerender = true` to `src/pages/blog/[...slug].astro`

## Related Issues

- Closes #5

## Checklist

- [x] `npm run build` passes without errors
- [x] Blog route generates static HTML (`/blog/test-post/index.html`)
- [x] No regressions in existing functionality
- [ ] I18n considered (if applicable)
- [x] SEO tags intact (if page changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)