### PR TITLE
fix(seo): consolidate meta tags and fix blog OG type

### DIFF
--- a/src/components/layout/SEO.astro
+++ b/src/components/layout/SEO.astro
@@ -4,34 +4,36 @@ interface Props {
     description?: string;
     image?: string;
     article?: boolean;
+    canonicalURL?: string;
+    robots?: string;
 }
 
-// 1. 設定預設值 (Default Values)
+const siteUrl = Astro.site ? Astro.site.href : "https://kairos-559.pages.dev";
+
 const {
     title = "K@i DIGITAL LAB | Senior TPM Portfolio",
     description = "Senior Technical Program Manager & Architecture Consultant. Bridging the gap between business requirements and technical excellence.",
-    image = "/og-image.jpg", // 預設的分享預覽圖 (我們稍後要準備這張圖)
+    image = "/og-image.jpg",
     article = false,
+    canonicalURL = new URL(Astro.url.pathname, siteUrl).href,
+    robots = "index, follow",
 } = Astro.props;
 
-// 2. 處理 URL 邏輯
-const siteUrl = Astro.site ? Astro.site.href : "https://kairos-559.pages.dev"; // Fallback 到您的 Pages 網址
-const canonicalURL = new URL(Astro.url.pathname, siteUrl);
 const socialImageURL = new URL(image, siteUrl);
 ---
 
+<meta name="description" content={description} />
+<meta name="robots" content={robots} />
 <link rel="canonical" href={canonicalURL} />
 
-<meta name="title" content={title} />
-
 <meta property="og:type" content={article ? "article" : "website"} />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={socialImageURL} />
 
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={socialImageURL} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,7 @@ interface Props {
     lang?: string;
     robots?: string;
     canonicalURL?: string;
+    article?: boolean;
 }
 
 const {
@@ -17,8 +18,9 @@ const {
     description = "Senior TPM & Modern Web Architecture Portfolio",
     image,
     lang = "en",
-    robots = "index, follow", // Default to indexed
-    canonicalURL = Astro.url.href, // Default to current URL
+    robots = "index, follow",
+    canonicalURL = Astro.url.href,
+    article = false,
 } = Astro.props;
 ---
 
@@ -26,14 +28,11 @@ const {
 <html lang={lang} class="scroll-smooth">
     <head>
         <meta charset="UTF-8" />
-        <meta name="description" content={description} />
-        <meta name="robots" content={robots} />
-        <link rel="canonical" href={canonicalURL} />
         <meta name="viewport" content="width=device-width" />
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
-        <SEO title={title} description={description} image={image} />
+        <SEO title={title} description={description} image={image} canonicalURL={canonicalURL} robots={robots} article={article} />
 
         <ClientRouter />
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -10,9 +10,10 @@ interface Props {
     lang?: string;
     robots?: string;
     canonicalURL?: string;
+    article?: boolean;
 }
 
-const { title, description, image, lang, robots, canonicalURL } = Astro.props;
+const { title, description, image, lang, robots, canonicalURL, article } = Astro.props;
 ---
 
 <BaseLayout
@@ -22,6 +23,7 @@ const { title, description, image, lang, robots, canonicalURL } = Astro.props;
     lang={lang}
     robots={robots}
     canonicalURL={canonicalURL}
+    article={article}
 >
     <Header />
     <main class="min-h-screen">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -42,6 +42,7 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
     description={post.data.description}
     robots={robots}
     canonicalURL={canonicalURL}
+    article={true}
 >
     <!-- Progress Indicator (Minimalist) -->
     <div
@@ -125,16 +126,18 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
     </article>
 
     <script>
-        // Simple scroll progress
-        window.addEventListener("scroll", () => {
-            const winScroll =
-                document.body.scrollTop || document.documentElement.scrollTop;
-            const height =
-                document.documentElement.scrollHeight -
-                document.documentElement.clientHeight;
-            const scrolled = (winScroll / height) * 100;
-            const bar = document.getElementById("scroll-progress");
-            if (bar) bar.style.width = scrolled + "%";
+        document.addEventListener("astro:page-load", () => {
+            const handler = () => {
+                const winScroll =
+                    document.body.scrollTop || document.documentElement.scrollTop;
+                const height =
+                    document.documentElement.scrollHeight -
+                    document.documentElement.clientHeight;
+                const scrolled = (winScroll / height) * 100;
+                const bar = document.getElementById("scroll-progress");
+                if (bar) bar.style.width = scrolled + "%";
+            };
+            window.addEventListener("scroll", handler);
         });
     </script>
 </PageLayout>


### PR DESCRIPTION
## Summary

Consolidate all SEO meta tags into a single source of truth (`SEO.astro`) and fix blog article OG type.

## Changes

- **SEO.astro**: Now accepts `canonicalURL`, `robots`, `article` props; outputs `description`, `robots`, `canonical` (previously duplicated in BaseLayout)
- **BaseLayout.astro**: Removed duplicate `<meta name="description">`, `<meta name="robots">`, `<link rel="canonical">`; passes all props through to SEO component
- **PageLayout.astro**: Added `article` prop pass-through
- **blog/[...slug].astro**: Added `article={true}` for correct `og:type`; fixed scroll listener to use `astro:page-load`

## Related Issues

- Addresses code review findings from blog SEO audit

## Checklist

- [x] `npm run build` passes without errors
- [x] Tested locally with `npm run dev`
- [x] No regressions in existing functionality
- [ ] I18n considered (if applicable)
- [x] SEO tags intact (if page changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)