### PR TITLE
feat(blog): add blog content pipeline with Medium syndication

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -10,6 +10,7 @@ const translations = {
         pricing: "Pricing",
         about: "About",
         contact: "Contact",
+        blog: "Blog",
         toggleLabel: "TW",
         toggleTitle: "Switch to Traditional Chinese",
         targetLang: "zh-tw",
@@ -20,6 +21,7 @@ const translations = {
         pricing: "方案價格",
         about: "關於我",
         contact: "聯絡資訊",
+        blog: "部落格",
         toggleLabel: "EN",
         toggleTitle: "Switch to English",
         targetLang: "en",
@@ -93,6 +95,13 @@ if (lang === "en") {
                         </a>
                     ))
                 }
+                <a
+                    href="/blog/"
+                    class="text-sm font-medium hover:text-primary-600 dark:hover:text-primary-400 transition-colors relative group"
+                >
+                    {t.blog}
+                    <span class="absolute -bottom-1 left-0 w-0 h-0.5 bg-primary-600 transition-all group-hover:w-full" />
+                </a>
 
                 <div
                     class="flex items-center ml-4 pl-4 border-l border-slate-200 dark:border-slate-700 gap-2"
@@ -172,6 +181,12 @@ if (lang === "en") {
                     </a>
                 ))
             }
+            <a
+                href="/blog/"
+                class="block px-3 py-3 rounded-md text-base font-medium text-slate-700 dark:text-slate-200 hover:text-primary-600 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
+            >
+                {t.blog}
+            </a>
         </div>
     </div>
 </header>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -54,6 +54,7 @@ const blogCollection = defineCollection({
         tags: z.array(z.string()).default(['Tech']),
         isDraft: z.boolean().default(false),
         canonicalURL: z.string().optional(),
+        mediumUrl: z.string().url().optional(),
     })
 });
 

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -122,6 +122,25 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
             >
                 <Content />
             </div>
+
+            <!-- Medium Syndication Link -->
+            {
+                post.data.mediumUrl && (
+                    <div class="mt-12 pt-8 border-t border-slate-200 dark:border-slate-800">
+                        <a
+                            href={post.data.mediumUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                        >
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
+                            </svg>
+                            Also available on Medium
+                        </a>
+                    </div>
+                )
+            }
         </div>
     </article>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,94 @@
+---
+import { getCollection } from "astro:content";
+import PageLayout from "@/layouts/PageLayout.astro";
+
+export const prerender = true;
+
+const posts = await getCollection("blog", ({ data }) => {
+    return import.meta.env.PROD ? !data.isDraft : true;
+});
+
+const sortedPosts = posts.sort(
+    (a, b) => b.data.pubDate.getTime() - a.data.pubDate.getTime()
+);
+---
+
+<PageLayout
+    title="Blog | K@i DIGITAL LAB"
+    description="Thoughts on technical program management, web architecture, and bridging business with technology."
+>
+    <section class="py-20 bg-white dark:bg-slate-900 min-h-screen">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+            <!-- Header -->
+            <div class="mb-16 text-center">
+                <h1
+                    class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white mb-4"
+                >
+                    Blog
+                </h1>
+                <p
+                    class="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto"
+                >
+                    Thoughts on technical program management, web architecture,
+                    and bridging business with technology.
+                </p>
+            </div>
+
+            <!-- Posts -->
+            {
+                sortedPosts.length === 0 ? (
+                    <p class="text-center text-slate-500 dark:text-slate-400">
+                        No posts yet. Stay tuned!
+                    </p>
+                ) : (
+                    <div class="space-y-8">
+                        {sortedPosts.map((post) => (
+                            <a
+                                href={`/blog/${post.slug}`}
+                                class="group block bg-white dark:bg-slate-800 rounded-2xl p-6 sm:p-8 shadow-sm hover:shadow-lg border border-slate-100 dark:border-slate-700 transition-all duration-300 hover:-translate-y-0.5"
+                            >
+                                <div class="flex items-center gap-3 mb-3 text-sm text-slate-500 dark:text-slate-400 font-mono">
+                                    <time
+                                        datetime={post.data.pubDate.toISOString()}
+                                    >
+                                        {post.data.pubDate.toLocaleDateString(
+                                            "en-US",
+                                            {
+                                                year: "numeric",
+                                                month: "long",
+                                                day: "numeric",
+                                            }
+                                        )}
+                                    </time>
+                                    {post.data.isDraft && (
+                                        <span class="px-2 py-0.5 text-xs font-bold tracking-wider text-amber-500 uppercase bg-amber-100 dark:bg-amber-900/30 rounded-full border border-amber-200 dark:border-amber-700">
+                                            Draft
+                                        </span>
+                                    )}
+                                </div>
+
+                                <h2 class="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                                    {post.data.title}
+                                </h2>
+
+                                <p class="text-slate-600 dark:text-slate-300 leading-relaxed mb-4">
+                                    {post.data.description}
+                                </p>
+
+                                {post.data.tags && (
+                                    <div class="flex flex-wrap gap-2">
+                                        {post.data.tags.map((tag) => (
+                                            <span class="px-2.5 py-0.5 text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 rounded-md">
+                                                #{tag}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                            </a>
+                        ))}
+                    </div>
+                )
+            }
+        </div>
+    </section>
+</PageLayout>


### PR DESCRIPTION
## Summary
- Add blog index page (`/blog/`) with SSG prerendering and draft filtering
- Add `mediumUrl` field to blog content schema for Medium syndication
- Add conditional "Also available on Medium" link to blog post page
- Add Blog/部落格 link to Header navigation (desktop + mobile)

## Changes
- `src/content/config.ts` — added `mediumUrl: z.string().url().optional()`
- `src/pages/blog/index.astro` — new blog listing page with card-style layout
- `src/pages/blog/[...slug].astro` — Medium syndication link after article content
- `src/components/layout/Header.astro` — Blog nav link (bilingual)

## Related Issues
Closes #10

## Checklist
- [x] Build passes (`npm run build`)
- [x] Tested locally
- [x] No regressions on existing pages
- [x] Bilingual support (Blog / 部落格)
- [x] SEO: canonical URL remains self-referencing on Kairos

🤖 Generated with [Claude Code](https://claude.com/claude-code)