### PR TITLE
feat(blog): add i18n support for blog articles

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -96,7 +96,7 @@ if (lang === "en") {
                     ))
                 }
                 <a
-                    href="/blog/"
+                    href={`/${lang}/blog/`}
                     class="text-sm font-medium hover:text-primary-600 dark:hover:text-primary-400 transition-colors relative group"
                 >
                     {t.blog}
@@ -182,7 +182,7 @@ if (lang === "en") {
                 ))
             }
             <a
-                href="/blog/"
+                href={`/${lang}/blog/`}
                 class="block px-3 py-3 rounded-md text-base font-medium text-slate-700 dark:text-slate-200 hover:text-primary-600 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors"
             >
                 {t.blog}

--- a/src/content/blog/test-post.md
+++ b/src/content/blog/test-post.md
@@ -2,6 +2,8 @@
 title: "The Future of Digital Portfolios: Why Static Sites Are Dead"
 description: "Exploring the shift from static layouts to dynamic, intent-based architectures like Project Insanity."
 pubDate: 2026-01-02
+language: "en"
+translationKey: "future-of-portfolios"
 author: "Kevin Hsieh"
 tags: ["Architecture", "Astro", "Philosophy"]
 isDraft: true

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -48,6 +48,8 @@ const blogCollection = defineCollection({
         title: z.string(),
         description: z.string(),
         pubDate: z.date(),
+        language: z.enum(['en', 'zh-tw']).default('en'),
+        translationKey: z.string().optional(),
         slug: z.string().optional(),
         author: z.string().default('Kevin Hsieh'),
         image: z.string().optional(),

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -1,29 +1,19 @@
 ---
-import { getCollection, getEntry, render } from "astro:content";
+import { getCollection, render } from "astro:content";
 import PageLayout from "@/layouts/PageLayout.astro";
 
 export const prerender = true;
 
-// Generate static paths for all blog posts
 export async function getStaticPaths() {
     const posts = await getCollection("blog");
     return posts.map((post) => ({
-        params: { slug: post.slug },
+        params: { lang: post.data.language, slug: post.slug },
         props: { post },
     }));
 }
 
-// Get the post from props (SSG) or fetch usage (Fallback)
-const { slug } = Astro.params;
-const propsPost = Astro.props.post;
-
-let post;
-
-if (propsPost) {
-    post = propsPost;
-} else if (slug) {
-    post = await getEntry("blog", slug);
-}
+const { lang } = Astro.params;
+const { post } = Astro.props;
 
 if (!post) {
     return Astro.redirect("/404");
@@ -31,10 +21,38 @@ if (!post) {
 
 const { Content } = await render(post);
 
+// Find translated version via translationKey
+let translatedPost = null;
+if (post.data.translationKey) {
+    const allPosts = await getCollection("blog");
+    translatedPost = allPosts.find(
+        (p) =>
+            p.data.translationKey === post.data.translationKey &&
+            p.data.language !== post.data.language
+    );
+}
+
+const targetLang = lang === "en" ? "zh-tw" : "en";
+
 // SEO Logic
 const isDraft = post.data.isDraft;
 const robots = isDraft ? "noindex, nofollow" : "index, follow";
 const canonicalURL = post.data.canonicalURL || Astro.url.href;
+const dateLocale = lang === "zh-tw" ? "zh-TW" : "en-US";
+
+const translations = {
+    en: {
+        draft: "Draft Preview",
+        readIn: "閱讀中文版",
+    },
+    "zh-tw": {
+        draft: "草稿預覽",
+        readIn: "Read in English",
+    },
+};
+
+const t =
+    translations[lang as keyof typeof translations] || translations.en;
 ---
 
 <PageLayout
@@ -62,7 +80,7 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
                 {
                     isDraft && (
                         <span class="inline-block px-3 py-1 mb-4 text-xs font-bold tracking-wider text-amber-500 uppercase bg-amber-100 dark:bg-amber-900/30 rounded-full border border-amber-200 dark:border-amber-700">
-                            Draft Preview
+                            {t.draft}
                         </span>
                     )
                 }
@@ -71,7 +89,7 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
                 >
                     <time datetime={post.data.pubDate.toISOString()}>
                         {
-                            post.data.pubDate.toLocaleDateString("en-US", {
+                            post.data.pubDate.toLocaleDateString(dateLocale, {
                                 year: "numeric",
                                 month: "long",
                                 day: "numeric",
@@ -103,6 +121,33 @@ const canonicalURL = post.data.canonicalURL || Astro.url.href;
                                     #{tag}
                                 </span>
                             ))}
+                        </div>
+                    )
+                }
+
+                <!-- Translation Link -->
+                {
+                    translatedPost && (
+                        <div class="mt-6">
+                            <a
+                                href={`/${targetLang}/blog/${translatedPost.slug}`}
+                                class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors border border-slate-200 dark:border-slate-700"
+                            >
+                                <svg
+                                    class="w-4 h-4"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="currentColor"
+                                >
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="m10.5 21 5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 0 1 6-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 0 1-3.827-5.802"
+                                    />
+                                </svg>
+                                {t.readIn}
+                            </a>
                         </div>
                     )
                 }

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -4,8 +4,35 @@ import PageLayout from "@/layouts/PageLayout.astro";
 
 export const prerender = true;
 
+export function getStaticPaths() {
+    return [{ params: { lang: "en" } }, { params: { lang: "zh-tw" } }];
+}
+
+const lang = Astro.currentLocale || "en";
+
+const translations = {
+    en: {
+        title: "Blog",
+        description:
+            "Thoughts on technical program management, web architecture, and bridging business with technology.",
+        noPost: "No posts yet. Stay tuned!",
+        draft: "Draft",
+    },
+    "zh-tw": {
+        title: "部落格",
+        description: "關於技術專案管理、網站架構與技術商業整合的思考。",
+        noPost: "尚無文章，敬請期待！",
+        draft: "草稿",
+    },
+};
+
+const t = translations[lang as keyof typeof translations] || translations.en;
+const dateLocale = lang === "zh-tw" ? "zh-TW" : "en-US";
+
 const posts = await getCollection("blog", ({ data }) => {
-    return import.meta.env.PROD ? !data.isDraft : true;
+    const langMatch = data.language === lang;
+    const draftFilter = import.meta.env.PROD ? !data.isDraft : true;
+    return langMatch && draftFilter;
 });
 
 const sortedPosts = posts.sort(
@@ -14,8 +41,8 @@ const sortedPosts = posts.sort(
 ---
 
 <PageLayout
-    title="Blog | K@i DIGITAL LAB"
-    description="Thoughts on technical program management, web architecture, and bridging business with technology."
+    title={`${t.title} | K@i DIGITAL LAB`}
+    description={t.description}
 >
     <section class="py-20 bg-white dark:bg-slate-900 min-h-screen">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -24,13 +51,12 @@ const sortedPosts = posts.sort(
                 <h1
                     class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white mb-4"
                 >
-                    Blog
+                    {t.title}
                 </h1>
                 <p
                     class="text-lg text-slate-600 dark:text-slate-400 max-w-2xl mx-auto"
                 >
-                    Thoughts on technical program management, web architecture,
-                    and bridging business with technology.
+                    {t.description}
                 </p>
             </div>
 
@@ -38,13 +64,13 @@ const sortedPosts = posts.sort(
             {
                 sortedPosts.length === 0 ? (
                     <p class="text-center text-slate-500 dark:text-slate-400">
-                        No posts yet. Stay tuned!
+                        {t.noPost}
                     </p>
                 ) : (
                     <div class="space-y-8">
                         {sortedPosts.map((post) => (
                             <a
-                                href={`/blog/${post.slug}`}
+                                href={`/${lang}/blog/${post.slug}`}
                                 class="group block bg-white dark:bg-slate-800 rounded-2xl p-6 sm:p-8 shadow-sm hover:shadow-lg border border-slate-100 dark:border-slate-700 transition-all duration-300 hover:-translate-y-0.5"
                             >
                                 <div class="flex items-center gap-3 mb-3 text-sm text-slate-500 dark:text-slate-400 font-mono">
@@ -52,7 +78,7 @@ const sortedPosts = posts.sort(
                                         datetime={post.data.pubDate.toISOString()}
                                     >
                                         {post.data.pubDate.toLocaleDateString(
-                                            "en-US",
+                                            dateLocale,
                                             {
                                                 year: "numeric",
                                                 month: "long",
@@ -62,7 +88,7 @@ const sortedPosts = posts.sort(
                                     </time>
                                     {post.data.isDraft && (
                                         <span class="px-2 py-0.5 text-xs font-bold tracking-wider text-amber-500 uppercase bg-amber-100 dark:bg-amber-900/30 rounded-full border border-amber-200 dark:border-amber-700">
-                                            Draft
+                                            {t.draft}
                                         </span>
                                     )}
                                 </div>


### PR DESCRIPTION
## Summary

- Move blog routes under `[lang]` prefix (`/en/blog/`, `/zh-tw/blog/`) to integrate with the site's i18n routing system
- Blog index filters articles by current language setting
- Article pages link to translated versions via `translationKey`
- Header blog link now uses locale-aware path
- Date format adapts to language (`en-US` / `zh-TW`)

## Changes

- **Schema**: Added `language` and `translationKey` fields to blog content collection
- **Routes**: Moved `src/pages/blog/` → `src/pages/[lang]/blog/`
- **Header**: Blog nav link updated to `/${lang}/blog/`
- **Content**: Test post updated with new frontmatter fields

## Test plan

- [ ] Visit `/en/blog/` — only English articles shown
- [ ] Visit `/zh-tw/blog/` — only Chinese articles shown
- [ ] Header language toggle switches between `/en/blog/` ↔ `/zh-tw/blog/`
- [ ] Article page shows "Read in other language" link when translation exists
- [ ] Date format matches locale
- [ ] Build passes without errors

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)