### PR TITLE
feat(ui): homepage real-data refactor and visual polish

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -13,7 +13,7 @@ const translations = {
     },
 };
 
-const t = translations[lang] || translations.en;
+const t = translations[lang as keyof typeof translations] || translations.en;
 ---
 
 <footer

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -165,7 +165,7 @@ const t = translations[locale];
                     class="mt-10 pt-8 border-t border-slate-200 dark:border-slate-800 flex items-center gap-4"
                 >
                     <a
-                        href="https://www.linkedin.com/in/kevin-hsieh-13264421/"
+                        href="https://www.linkedin.com/in/kevinhsieh-pmp/"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="inline-flex items-center font-semibold text-primary-600 hover:text-primary-700 transition-colors"

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -35,10 +35,12 @@ const t = translations[lang as keyof typeof translations] || translations.en;
 
 <section
     id="contact"
-    class="py-24 bg-slate-50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-800"
+    class="py-24 bg-slate-50 dark:bg-slate-950 border-t border-slate-200 dark:border-slate-800"
 >
     <div class="max-w-4xl mx-auto px-4 text-center">
-        <h2 class="text-3xl font-bold text-slate-900 dark:text-white mb-6">
+        <h2
+            class="text-3xl md:text-4xl font-bold font-mono text-slate-900 dark:text-white mb-6"
+        >
             {t.title}
         </h2>
         <p

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -30,7 +30,7 @@ const translations = {
     },
 };
 
-const t = translations[lang] || translations.en;
+const t = translations[lang as keyof typeof translations] || translations.en;
 ---
 
 <section

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -82,7 +82,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
             </a>
 
             <a
-                href="https://www.linkedin.com/in/kevin-hsieh-13264421/"
+                href="https://www.linkedin.com/in/kevinhsieh-pmp/"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="group bg-white dark:bg-slate-800 p-8 rounded-2xl shadow-sm hover:shadow-md border border-slate-200 dark:border-slate-700 transition-all text-left flex items-start gap-4"

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -3,6 +3,7 @@ const lang = Astro.currentLocale || "en";
 
 const translations = {
     en: {
+        statusPill: "Open to Senior TPM & consulting opportunities",
         titleLine1: "Global Vision,",
         titleLine2: "Local Excellence",
         subtitle:
@@ -11,6 +12,7 @@ const translations = {
         ctaSecondary: "About Me",
     },
     "zh-tw": {
+        statusPill: "開放資深 TPM 職缺與顧問合作洽談",
         titleLine1: "全球視野，",
         titleLine2: "深耕在地",
         subtitle: "資深技術專案經理，連結商業策略與工程執行的關鍵橋樑。",
@@ -58,6 +60,20 @@ const t = translations[lang as keyof typeof translations] || translations.en;
     <div
         class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative z-10 text-center"
     >
+        <a
+            href="#contact"
+            class="inline-flex items-center gap-2 px-4 py-1.5 mb-8 rounded-full bg-white/60 dark:bg-slate-800/60 backdrop-blur-sm border border-slate-200 dark:border-slate-700 text-sm font-medium text-slate-700 dark:text-slate-200 hover:border-emerald-400 dark:hover:border-emerald-500 transition-colors"
+        >
+            <span class="relative flex h-2 w-2">
+                <span
+                    class="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
+                <span
+                    class="relative inline-flex rounded-full h-2 w-2 bg-emerald-500"
+                ></span>
+            </span>
+            {t.statusPill}
+        </a>
+
         <h1
             class="text-5xl md:text-7xl font-extrabold tracking-tight text-slate-900 dark:text-white mb-6 drop-shadow-sm"
         >
@@ -81,7 +97,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
         >
             <a
                 href="#portfolio"
-                class="inline-flex items-center justify-center px-8 py-3 text-base font-medium text-white bg-primary-600 hover:bg-primary-700 rounded-lg shadow-lg shadow-primary-500/20 transition-all duration-300 hover:-translate-y-1"
+                class="inline-flex items-center justify-center px-8 py-3 text-base font-semibold text-white bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 rounded-lg shadow-lg shadow-purple-500/25 transition-all duration-300 hover:-translate-y-1"
             >
                 {t.ctaPrimary}
             </a>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -19,7 +19,7 @@ const translations = {
     },
 };
 
-const t = translations[lang] || translations.en;
+const t = translations[lang as keyof typeof translations] || translations.en;
 ---
 
 <section

--- a/src/components/sections/Portfolio.astro
+++ b/src/components/sections/Portfolio.astro
@@ -139,7 +139,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
 
 <section
     id="portfolio"
-    class="py-20 bg-slate-50 dark:bg-slate-900/50 transition-colors duration-300"
+    class="py-20 bg-slate-50 dark:bg-slate-950 transition-colors duration-300"
 >
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="text-center mb-16">
@@ -160,12 +160,20 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                 cards.map((card) => (
                     <div
                         data-showcase-card
-                        class="group bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative flex flex-col"
+                        class={`group bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative flex flex-col ${
+                            card.key === "software"
+                                ? "md:col-span-2 md:flex-row"
+                                : ""
+                        }`}
                     >
                         {/* Mini layout preview on the category gradient */}
                         <a
                             href={`/${lang}/explore/${card.slug}`}
-                            class={`aspect-video w-full bg-gradient-to-br ${card.gradient} relative overflow-hidden block`}
+                            class={`aspect-video w-full bg-gradient-to-br ${card.gradient} relative overflow-hidden block ${
+                                card.key === "software"
+                                    ? "md:w-1/2 md:aspect-auto"
+                                    : ""
+                            }`}
                         >
                             <div class="absolute inset-0 p-5 transform group-hover:scale-[1.03] transition-transform duration-500">
                                 {card.key === "portfolio" && (
@@ -190,13 +198,13 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                                 )}
                                 {card.key === "ecommerce" && (
                                     <div class="h-full flex flex-col gap-2">
-                                        <div class="h-2 w-1/3 bg-white/50 rounded" />
+                                        <div class="h-2 w-1/3 bg-white/60 rounded" />
                                         <div class="grid grid-cols-3 gap-2 flex-1">
                                             {[1, 2, 3].map(() => (
-                                                <div class="bg-white/20 rounded-lg p-2 flex flex-col gap-1.5">
-                                                    <div class="flex-1 bg-white/30 rounded" />
-                                                    <div class="h-1.5 w-3/4 bg-white/50 rounded" />
-                                                    <div class="h-1.5 w-1/3 bg-white/70 rounded" />
+                                                <div class="bg-white/30 rounded-lg p-2 flex flex-col gap-1.5">
+                                                    <div class="flex-1 bg-white/40 rounded" />
+                                                    <div class="h-1.5 w-3/4 bg-white/60 rounded" />
+                                                    <div class="h-1.5 w-1/3 bg-white/80 rounded" />
                                                 </div>
                                             ))}
                                         </div>
@@ -205,33 +213,33 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                                 {card.key === "corporate" && (
                                     <div class="h-full flex flex-col gap-2">
                                         <div class="flex justify-between items-center">
-                                            <div class="h-2 w-12 bg-white/60 rounded" />
+                                            <div class="h-2 w-12 bg-white/70 rounded" />
                                             <div class="flex gap-1.5">
                                                 {[1, 2, 3].map(() => (
-                                                    <div class="h-1.5 w-7 bg-white/40 rounded" />
+                                                    <div class="h-1.5 w-7 bg-white/50 rounded" />
                                                 ))}
                                             </div>
                                         </div>
-                                        <div class="flex-1 bg-white/20 rounded-lg flex flex-col items-center justify-center gap-2">
-                                            <div class="h-2.5 w-1/2 bg-white/50 rounded" />
-                                            <div class="h-1.5 w-1/3 bg-white/40 rounded" />
+                                        <div class="flex-1 bg-white/30 rounded-lg flex flex-col items-center justify-center gap-2">
+                                            <div class="h-2.5 w-1/2 bg-white/60 rounded" />
+                                            <div class="h-1.5 w-1/3 bg-white/50 rounded" />
                                         </div>
                                         <div class="grid grid-cols-3 gap-2 h-8">
                                             {[1, 2, 3].map(() => (
-                                                <div class="bg-white/25 rounded-lg" />
+                                                <div class="bg-white/35 rounded-lg" />
                                             ))}
                                         </div>
                                     </div>
                                 )}
                                 {card.key === "content" && (
                                     <div class="h-full flex flex-col gap-2">
-                                        <div class="h-3 w-1/2 bg-white/60 rounded mx-auto" />
+                                        <div class="h-3 w-1/2 bg-white/70 rounded mx-auto" />
                                         <div class="grid grid-cols-3 gap-3 flex-1">
-                                            <div class="bg-white/25 rounded-lg" />
+                                            <div class="bg-white/35 rounded-lg" />
                                             {[1, 2].map(() => (
                                                 <div class="flex flex-col gap-1.5 pt-1">
                                                     {[1, 2, 3, 4, 5].map(() => (
-                                                        <div class="h-1.5 bg-white/40 rounded last:w-2/3" />
+                                                        <div class="h-1.5 bg-white/50 rounded last:w-2/3" />
                                                     ))}
                                                 </div>
                                             ))}
@@ -240,18 +248,18 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                                 )}
                                 {card.key === "software" && (
                                     <div class="h-full flex gap-2">
-                                        <div class="w-1/5 bg-white/20 rounded-lg p-2 flex flex-col gap-1.5">
+                                        <div class="w-1/5 bg-white/30 rounded-lg p-2 flex flex-col gap-1.5">
                                             {[1, 2, 3, 4].map(() => (
-                                                <div class="h-1.5 bg-white/40 rounded" />
+                                                <div class="h-1.5 bg-white/50 rounded" />
                                             ))}
                                         </div>
                                         <div class="flex-1 flex flex-col gap-2">
                                             <div class="grid grid-cols-3 gap-2 h-9">
                                                 {[1, 2, 3].map(() => (
-                                                    <div class="bg-white/25 rounded-lg" />
+                                                    <div class="bg-white/35 rounded-lg" />
                                                 ))}
                                             </div>
-                                            <div class="flex-1 bg-white/20 rounded-lg flex items-end gap-1.5 p-2">
+                                            <div class="flex-1 bg-white/30 rounded-lg flex items-end gap-1.5 p-2">
                                                 {[
                                                     "h-1/3",
                                                     "h-2/3",
@@ -261,7 +269,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                                                     "h-2/5",
                                                 ].map((height) => (
                                                     <div
-                                                        class={`flex-1 ${height} bg-white/50 rounded-t`}
+                                                        class={`flex-1 ${height} bg-white/60 rounded-t`}
                                                     />
                                                 ))}
                                             </div>

--- a/src/components/sections/Portfolio.astro
+++ b/src/components/sections/Portfolio.astro
@@ -1,10 +1,77 @@
 ---
+import { getEntry } from "astro:content";
+
 const lang = Astro.currentLocale || "en";
 
+// Per-category chrome: accent styling + themes collection entry id.
+// Theme names/ids come from the themes collection; project preview
+// images come from the projects collection — no hardcoded content.
+const categoryMeta = [
+    {
+        key: "portfolio",
+        slug: "portfolio",
+        themesId: "portfolio",
+        gradient: "from-pink-500 to-purple-600",
+        hoverTitle:
+            "group-hover:text-primary-600 dark:group-hover:text-primary-400",
+        linkAccent: "text-primary-600 dark:text-primary-400",
+    },
+    {
+        key: "ecommerce",
+        slug: "ecommerce",
+        themesId: "ecommerce",
+        gradient: "from-emerald-500 to-teal-600",
+        hoverTitle:
+            "group-hover:text-emerald-600 dark:group-hover:text-emerald-400",
+        linkAccent: "text-emerald-600 dark:text-emerald-400",
+    },
+    {
+        key: "corporate",
+        slug: "corporate",
+        themesId: "corporate",
+        gradient: "from-blue-600 to-indigo-700",
+        hoverTitle:
+            "group-hover:text-blue-600 dark:group-hover:text-blue-400",
+        linkAccent: "text-blue-600 dark:text-blue-400",
+    },
+    {
+        key: "content",
+        slug: "content-news",
+        themesId: "content-news",
+        gradient: "from-rose-500 to-orange-600",
+        hoverTitle:
+            "group-hover:text-rose-600 dark:group-hover:text-rose-400",
+        linkAccent: "text-rose-600 dark:text-rose-400",
+    },
+    {
+        key: "software",
+        slug: "software",
+        themesId: "software",
+        gradient: "from-cyan-500 to-blue-600",
+        hoverTitle:
+            "group-hover:text-cyan-600 dark:group-hover:text-cyan-400",
+        linkAccent: "text-cyan-600 dark:text-cyan-400",
+    },
+] as const;
+
+const themeEntries = await Promise.all(
+    categoryMeta.map((c) => getEntry("themes", `${c.themesId}-${lang}`)),
+);
+const cards = categoryMeta.map((meta, i) => ({
+    ...meta,
+    themes: themeEntries[i]?.data ?? [],
+}));
+
+// Real project images feed the portfolio card's mini waterfall preview
+const projectsEntry = await getEntry("projects", `projects-${lang}`);
+const previewProjects = (projectsEntry?.data ?? []).slice(0, 3);
+
+// UI chrome strings only — theme names and preview images come from data
 const translations = {
     en: {
         sectionTitle: "Interactive Capability Showcase",
         sectionSubtitle: 'Experience our "Project Insanity" engine.',
+        themesLabel: "themes",
         categories: {
             portfolio: {
                 title: "Portfolio Collections",
@@ -36,6 +103,7 @@ const translations = {
     "zh-tw": {
         sectionTitle: "互動能力展示",
         sectionSubtitle: "體驗我們的「Project Insanity」引擎。",
+        themesLabel: "種版型",
         categories: {
             portfolio: {
                 title: "精選作品集",
@@ -87,322 +155,248 @@ const t = translations[lang as keyof typeof translations] || translations.en;
             </p>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <!-- Portfolio Category Card -->
-            <a
-                href={`/${lang}/explore/portfolio/VisualDesigner`}
-                class="group block bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative"
-            >
-                <div
-                    class="aspect-video w-full bg-gradient-to-br from-pink-500 to-purple-600 relative overflow-hidden"
-                >
+        <showcase-rotator class="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {
+                cards.map((card) => (
                     <div
-                        class="absolute inset-0 bg-black/10 group-hover:bg-transparent transition-colors"
+                        data-showcase-card
+                        class="group bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative flex flex-col"
                     >
-                    </div>
-                    <!-- Placeholder for dynamic preview - using simple text/icon for now -->
-                    <div
-                        class="absolute inset-0 flex items-center justify-center text-white opacity-90"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-20 w-20 transform group-hover:scale-110 transition-transform duration-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
+                        {/* Mini layout preview on the category gradient */}
+                        <a
+                            href={`/${lang}/explore/${card.slug}`}
+                            class={`aspect-video w-full bg-gradient-to-br ${card.gradient} relative overflow-hidden block`}
                         >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                            ></path>
-                        </svg>
-                    </div>
-                </div>
+                            <div class="absolute inset-0 p-5 transform group-hover:scale-[1.03] transition-transform duration-500">
+                                {card.key === "portfolio" && (
+                                    <div class="h-full grid grid-cols-3 gap-2">
+                                        {previewProjects.map(
+                                            (project, index) => (
+                                                <img
+                                                    src={project.heroImage}
+                                                    alt={project.title}
+                                                    loading="lazy"
+                                                    class={`w-full object-cover rounded-lg shadow ${
+                                                        index === 1
+                                                            ? "h-4/5 self-end"
+                                                            : index === 2
+                                                              ? "h-5/6"
+                                                              : "h-full"
+                                                    }`}
+                                                />
+                                            ),
+                                        )}
+                                    </div>
+                                )}
+                                {card.key === "ecommerce" && (
+                                    <div class="h-full flex flex-col gap-2">
+                                        <div class="h-2 w-1/3 bg-white/50 rounded" />
+                                        <div class="grid grid-cols-3 gap-2 flex-1">
+                                            {[1, 2, 3].map(() => (
+                                                <div class="bg-white/20 rounded-lg p-2 flex flex-col gap-1.5">
+                                                    <div class="flex-1 bg-white/30 rounded" />
+                                                    <div class="h-1.5 w-3/4 bg-white/50 rounded" />
+                                                    <div class="h-1.5 w-1/3 bg-white/70 rounded" />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                {card.key === "corporate" && (
+                                    <div class="h-full flex flex-col gap-2">
+                                        <div class="flex justify-between items-center">
+                                            <div class="h-2 w-12 bg-white/60 rounded" />
+                                            <div class="flex gap-1.5">
+                                                {[1, 2, 3].map(() => (
+                                                    <div class="h-1.5 w-7 bg-white/40 rounded" />
+                                                ))}
+                                            </div>
+                                        </div>
+                                        <div class="flex-1 bg-white/20 rounded-lg flex flex-col items-center justify-center gap-2">
+                                            <div class="h-2.5 w-1/2 bg-white/50 rounded" />
+                                            <div class="h-1.5 w-1/3 bg-white/40 rounded" />
+                                        </div>
+                                        <div class="grid grid-cols-3 gap-2 h-8">
+                                            {[1, 2, 3].map(() => (
+                                                <div class="bg-white/25 rounded-lg" />
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                {card.key === "content" && (
+                                    <div class="h-full flex flex-col gap-2">
+                                        <div class="h-3 w-1/2 bg-white/60 rounded mx-auto" />
+                                        <div class="grid grid-cols-3 gap-3 flex-1">
+                                            <div class="bg-white/25 rounded-lg" />
+                                            {[1, 2].map(() => (
+                                                <div class="flex flex-col gap-1.5 pt-1">
+                                                    {[1, 2, 3, 4, 5].map(() => (
+                                                        <div class="h-1.5 bg-white/40 rounded last:w-2/3" />
+                                                    ))}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+                                {card.key === "software" && (
+                                    <div class="h-full flex gap-2">
+                                        <div class="w-1/5 bg-white/20 rounded-lg p-2 flex flex-col gap-1.5">
+                                            {[1, 2, 3, 4].map(() => (
+                                                <div class="h-1.5 bg-white/40 rounded" />
+                                            ))}
+                                        </div>
+                                        <div class="flex-1 flex flex-col gap-2">
+                                            <div class="grid grid-cols-3 gap-2 h-9">
+                                                {[1, 2, 3].map(() => (
+                                                    <div class="bg-white/25 rounded-lg" />
+                                                ))}
+                                            </div>
+                                            <div class="flex-1 bg-white/20 rounded-lg flex items-end gap-1.5 p-2">
+                                                {[
+                                                    "h-1/3",
+                                                    "h-2/3",
+                                                    "h-1/2",
+                                                    "h-full",
+                                                    "h-3/4",
+                                                    "h-2/5",
+                                                ].map((height) => (
+                                                    <div
+                                                        class={`flex-1 ${height} bg-white/50 rounded-t`}
+                                                    />
+                                                ))}
+                                            </div>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        </a>
 
-                <div class="p-8">
-                    <h3
-                        class="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors"
-                    >
-                        {t.categories.portfolio.title}
-                    </h3>
-                    <p
-                        class="text-slate-600 dark:text-slate-400 leading-relaxed mb-6"
-                    >
-                        {t.categories.portfolio.desc}
-                    </p>
-                    <span
-                        class="inline-flex items-center text-primary-600 dark:text-primary-400 font-semibold group-hover:underline"
-                    >
-                        {t.categories.portfolio.cta}
-                        <svg
-                            class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-                        </svg>
-                    </span>
-                </div>
-            </a>
+                        <div class="p-8 flex flex-col flex-1">
+                            <div class="flex items-baseline justify-between gap-2 mb-3">
+                                <h3
+                                    class={`text-2xl font-bold text-slate-900 dark:text-white transition-colors ${card.hoverTitle}`}
+                                >
+                                    {
+                                        t.categories[
+                                            card.key as keyof typeof t.categories
+                                        ].title
+                                    }
+                                </h3>
+                                <span class="text-xs text-slate-400 dark:text-slate-500 whitespace-nowrap font-mono">
+                                    {card.themes.length} {t.themesLabel}
+                                </span>
+                            </div>
+                            <p class="text-slate-600 dark:text-slate-400 leading-relaxed mb-5">
+                                {
+                                    t.categories[
+                                        card.key as keyof typeof t.categories
+                                    ].desc
+                                }
+                            </p>
 
-            <!-- E-Commerce Category Card -->
-            <a
-                href={`/${lang}/explore/ecommerce`}
-                class="group block bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative"
-            >
-                <div
-                    class="aspect-video w-full bg-gradient-to-br from-emerald-500 to-teal-600 relative overflow-hidden"
-                >
-                    <div
-                        class="absolute inset-0 bg-black/10 group-hover:bg-transparent transition-colors"
-                    >
-                    </div>
-                    <div
-                        class="absolute inset-0 flex items-center justify-center text-white opacity-90"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-20 w-20 transform group-hover:scale-110 transition-transform duration-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
-                            ></path>
-                        </svg>
-                    </div>
-                </div>
+                            {/* Theme chips — real theme names, deep links */}
+                            <div class="flex flex-wrap gap-2 mb-6">
+                                {card.themes.map((theme, index) => (
+                                    <a
+                                        href={`/${lang}/explore/${card.slug}/${theme.id}`}
+                                        data-chip
+                                        class={`text-xs px-2.5 py-1 rounded-full transition-colors duration-300 ${
+                                            index === 0
+                                                ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                                                : "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-600"
+                                        }`}
+                                    >
+                                        {theme.name}
+                                    </a>
+                                ))}
+                            </div>
 
-                <div class="p-8">
-                    <h3
-                        class="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors"
-                    >
-                        {t.categories.ecommerce.title}
-                    </h3>
-                    <p
-                        class="text-slate-600 dark:text-slate-400 leading-relaxed mb-6"
-                    >
-                        {t.categories.ecommerce.desc}
-                    </p>
-                    <span
-                        class="inline-flex items-center text-emerald-600 dark:text-emerald-400 font-semibold group-hover:underline"
-                    >
-                        {t.categories.ecommerce.cta}
-                        <svg
-                            class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-                        </svg>
-                    </span>
-                </div>
-            </a>
-
-            <!-- Corporate Category Card -->
-            <a
-                href={`/${lang}/explore/corporate`}
-                class="group block bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative"
-            >
-                <div
-                    class="aspect-video w-full bg-gradient-to-br from-blue-600 to-indigo-700 relative overflow-hidden"
-                >
-                    <div
-                        class="absolute inset-0 bg-black/10 group-hover:bg-transparent transition-colors"
-                    >
+                            <a
+                                href={`/${lang}/explore/${card.slug}`}
+                                class={`mt-auto inline-flex items-center font-semibold hover:underline ${card.linkAccent}`}
+                            >
+                                {
+                                    t.categories[
+                                        card.key as keyof typeof t.categories
+                                    ].cta
+                                }
+                                <svg
+                                    class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                        d="M17 8l4 4m0 0l-4 4m4-4H3"
+                                    ></path>
+                                </svg>
+                            </a>
+                        </div>
                     </div>
-                    <div
-                        class="absolute inset-0 flex items-center justify-center text-white opacity-90"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-20 w-20 transform group-hover:scale-110 transition-transform duration-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                            ></path>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="p-8">
-                    <h3
-                        class="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
-                    >
-                        {t.categories.corporate.title}
-                    </h3>
-                    <p
-                        class="text-slate-600 dark:text-slate-400 leading-relaxed mb-6"
-                    >
-                        {t.categories.corporate.desc}
-                    </p>
-                    <span
-                        class="inline-flex items-center text-blue-600 dark:text-blue-400 font-semibold group-hover:underline"
-                    >
-                        {t.categories.corporate.cta}
-                        <svg
-                            class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-                        </svg>
-                    </span>
-                </div>
-            </a>
-
-            <!-- Content/News Category Card -->
-            <a
-                href={`/${lang}/explore/content-news`}
-                class="group block bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative"
-            >
-                <div
-                    class="aspect-video w-full bg-gradient-to-br from-rose-500 to-orange-600 relative overflow-hidden"
-                >
-                    <div
-                        class="absolute inset-0 bg-black/10 group-hover:bg-transparent transition-colors"
-                    >
-                    </div>
-                    <div
-                        class="absolute inset-0 flex items-center justify-center text-white opacity-90"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-20 w-20 transform group-hover:scale-110 transition-transform duration-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"
-                            ></path>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="p-8">
-                    <h3
-                        class="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-rose-600 dark:group-hover:text-rose-400 transition-colors"
-                    >
-                        {t.categories.content.title}
-                    </h3>
-                    <p
-                        class="text-slate-600 dark:text-slate-400 leading-relaxed mb-6"
-                    >
-                        {t.categories.content.desc}
-                    </p>
-                    <span
-                        class="inline-flex items-center text-rose-600 dark:text-rose-400 font-semibold group-hover:underline"
-                    >
-                        {t.categories.content.cta}
-                        <svg
-                            class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-                        </svg>
-                    </span>
-                </div>
-            </a>
-
-            <!-- Software/SaaS Category Card -->
-            <a
-                href={`/${lang}/explore/software`}
-                class="group block bg-white dark:bg-slate-800 rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 border border-slate-100 dark:border-slate-700 relative"
-            >
-                <div
-                    class="aspect-video w-full bg-gradient-to-br from-cyan-500 to-blue-600 relative overflow-hidden"
-                >
-                    <div
-                        class="absolute inset-0 bg-black/10 group-hover:bg-transparent transition-colors"
-                    >
-                    </div>
-                    <div
-                        class="absolute inset-0 flex items-center justify-center text-white opacity-90"
-                    >
-                        <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-20 w-20 transform group-hover:scale-110 transition-transform duration-500"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="1.5"
-                                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-                            ></path>
-                        </svg>
-                    </div>
-                </div>
-
-                <div class="p-8">
-                    <h3
-                        class="text-2xl font-bold text-slate-900 dark:text-white mb-3 group-hover:text-cyan-600 dark:group-hover:text-cyan-400 transition-colors"
-                    >
-                        {t.categories.software.title}
-                    </h3>
-                    <p
-                        class="text-slate-600 dark:text-slate-400 leading-relaxed mb-6"
-                    >
-                        {t.categories.software.desc}
-                    </p>
-                    <span
-                        class="inline-flex items-center text-cyan-600 dark:text-cyan-400 font-semibold group-hover:underline"
-                    >
-                        {t.categories.software.cta}
-                        <svg
-                            class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-1"
-                            fill="none"
-                            viewBox="0 0 24 24"
-                            stroke="currentColor"
-                        >
-                            <path
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                stroke-width="2"
-                                d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-                        </svg>
-                    </span>
-                </div>
-            </a>
-        </div>
+                ))
+            }
+        </showcase-rotator>
     </div>
 </section>
+
+<script>
+    // 主題徽章輪替 Web Component：每張卡每 3 秒輪流高亮下一個主題，
+    // hover 該卡時暫停。計時器於 disconnectedCallback 清除，
+    // View Transitions 換頁後不殘留。
+    class ShowcaseRotator extends HTMLElement {
+        private timer: ReturnType<typeof setInterval> | null = null;
+
+        connectedCallback() {
+            const cards = [
+                ...this.querySelectorAll<HTMLElement>("[data-showcase-card]"),
+            ];
+            const activeIndexes = cards.map(() => 0);
+
+            // 與伺服器端渲染的 chip 樣式保持一致
+            const ACTIVE = [
+                "bg-slate-900",
+                "text-white",
+                "dark:bg-white",
+                "dark:text-slate-900",
+            ];
+            const INACTIVE = [
+                "bg-slate-100",
+                "text-slate-600",
+                "dark:bg-slate-700",
+                "dark:text-slate-300",
+                "hover:bg-slate-200",
+                "dark:hover:bg-slate-600",
+            ];
+
+            this.timer = setInterval(() => {
+                cards.forEach((card, c) => {
+                    if (card.matches(":hover")) return;
+                    const chips =
+                        card.querySelectorAll<HTMLElement>("[data-chip]");
+                    if (chips.length <= 1) return;
+
+                    activeIndexes[c] = (activeIndexes[c] + 1) % chips.length;
+                    chips.forEach((chip, i) => {
+                        const active = i === activeIndexes[c];
+                        chip.classList.remove(
+                            ...(active ? INACTIVE : ACTIVE),
+                        );
+                        chip.classList.add(...(active ? ACTIVE : INACTIVE));
+                    });
+                });
+            }, 3000);
+        }
+
+        disconnectedCallback() {
+            if (this.timer) clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    if (!customElements.get("showcase-rotator")) {
+        customElements.define("showcase-rotator", ShowcaseRotator);
+    }
+</script>

--- a/src/components/sections/Pricing.astro
+++ b/src/components/sections/Pricing.astro
@@ -1,39 +1,48 @@
 ---
+import { getEntry } from "astro:content";
+import type { ProjectData } from "@/stores/portfolio.store";
+
 const lang = Astro.currentLocale || "en";
 
+// Plans come from the pricing collection; example chips cross-reference
+// the projects collection (ADR-0008 pattern).
+const pricingEntry = await getEntry("pricing", `pricing-${lang}`);
+const plans = pricingEntry?.data ?? [];
+
+const projectsEntry = await getEntry("projects", `projects-${lang}`);
+const projects: ProjectData[] = projectsEntry?.data ?? [];
+
+// Deep-link each example project to the explorer lens that surfaces it best
+const themeForProject = (p: ProjectData) =>
+    p.designer
+        ? "VisualDesigner"
+        : p.caseStudy
+          ? "UXUIDesigner"
+          : "SoftwareEngineer";
+
+const resolvedPlans = plans.map((plan) => ({
+    ...plan,
+    examples: (plan.exampleProjectIds ?? [])
+        .map((id) => projects.find((p) => p.id === id))
+        .filter((p): p is ProjectData => Boolean(p))
+        .map((p) => ({
+            title: p.title,
+            href: `/${lang}/explore/portfolio/${themeForProject(p)}`,
+        })),
+}));
+
+// SSR initial currency follows the locale; the client swaps to the
+// visitor's persisted preference if one exists.
+const defaultCurrency = lang === "zh-tw" ? "twd" : "usd";
+
+// UI chrome strings only — plan content comes from the pricing collection
 const translations = {
     en: {
         title: "Transparent Investment",
         subtitle:
             "Professional web development packages tailored to your business needs.",
-        mvpTitle: "Landing Page",
-        mvpPrice: "$1,500",
-        mvpPer: "/ starting",
-        growthTitle: "Business Website",
-        growthPrice: "$4,800",
-        growthPer: "/ starting",
-        enterpriseTitle: "Custom Web App",
-        enterprisePrice: "$10k+",
-        enterprisePer: "/ project",
-        features: {
-            onePage: "High-Converting Single Page",
-            responsive: "Fully Mobile Responsive",
-            contact: "Contact Form & Lead Gen",
-            fastDelivery: "5-7 Day Turnaround",
-            multiPage: "Up to 8 Custom Pages",
-            cms: "Easy-to-use CMS (Manage Content)",
-            seo: "Technical SEO & Analytics",
-            training: "Handover Training & Docs",
-            react: "React / Next.js Architecture",
-            database: "Database & Auth Integration",
-            api: "Custom API Development",
-            support: "30 Days Post-Launch Support",
-        },
-        buttons: {
-            start: "Start Project",
-            select: "Most Popular",
-            contact: "Get a Quote",
-        },
+        popularBadge: "Most Popular",
+        examplesLabel: "Real work in this tier",
         footer: {
             secure: "Secure Payment",
             fast: "Fast Delivery",
@@ -42,34 +51,8 @@ const translations = {
     "zh-tw": {
         title: "透明的投資方案",
         subtitle: "專為您的商業需求量身打造的專業網頁開發方案。",
-        mvpTitle: "形象著陸頁",
-        mvpPrice: "$1,500",
-        mvpPer: "/ 起",
-        growthTitle: "商業形象網站",
-        growthPrice: "$4,800",
-        growthPer: "/ 起",
-        enterpriseTitle: "客製化 Web App",
-        enterprisePrice: "$10k+",
-        enterprisePer: "/ 專案",
-        features: {
-            onePage: "高轉換率單頁設計",
-            responsive: "完全響應式 (手機友善)",
-            contact: "聯絡表單與潛在客戶收集",
-            fastDelivery: "5-7 天快速交付",
-            multiPage: "最多 8 個客製化頁面",
-            cms: "易用的後台 (內容管理)",
-            seo: "技術 SEO 與分析設定",
-            training: "移交教育訓練與文件",
-            react: "React / Next.js 架構",
-            database: "資料庫與會員驗證整合",
-            api: "客製化 API 開發",
-            support: "上線後 30 天技術支援",
-        },
-        buttons: {
-            start: "開始專案",
-            select: "最受歡迎",
-            contact: "索取報價",
-        },
+        popularBadge: "最受歡迎",
+        examplesLabel: "此級距的實際案例",
         footer: {
             secure: "安全支付",
             fast: "快速交付",
@@ -77,49 +60,7 @@ const translations = {
     },
 };
 
-const t = translations[lang] || translations.en;
-
-const plans = [
-    {
-        title: t.mvpTitle,
-        price: t.mvpPrice,
-        period: t.mvpPer,
-        features: [
-            t.features.onePage,
-            t.features.responsive,
-            t.features.contact,
-            t.features.fastDelivery,
-        ],
-        buttonText: t.buttons.start,
-        isPopular: false,
-    },
-    {
-        title: t.growthTitle,
-        price: t.growthPrice,
-        period: t.growthPer,
-        features: [
-            t.features.multiPage,
-            t.features.cms,
-            t.features.seo,
-            t.features.training,
-        ],
-        buttonText: t.buttons.select,
-        isPopular: true,
-    },
-    {
-        title: t.enterpriseTitle,
-        price: t.enterprisePrice,
-        period: t.enterprisePer,
-        features: [
-            t.features.react,
-            t.features.database,
-            t.features.api,
-            t.features.support,
-        ],
-        buttonText: t.buttons.contact,
-        isPopular: false,
-    },
-];
+const t = translations[lang as keyof typeof translations] || translations.en;
 ---
 
 <section
@@ -143,8 +84,11 @@ const plans = [
         </div>
     </div>
 
-    <div class="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="text-center mb-20">
+    <currency-toggle
+        class="relative z-10 block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8"
+        data-default-currency={defaultCurrency}
+    >
+        <div class="text-center mb-12">
             <h2
                 class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white tracking-tight mb-6 drop-shadow-sm transition-colors"
             >
@@ -157,11 +101,40 @@ const plans = [
             </p>
         </div>
 
+        <!-- Currency Switch -->
+        <div class="flex justify-center mb-12">
+            <div
+                class="inline-flex items-center gap-1 p-1 rounded-full bg-slate-200 dark:bg-slate-800 transition-colors"
+                role="group"
+                aria-label="Currency"
+            >
+                {
+                    (["usd", "twd"] as const).map((currency) => (
+                        <button
+                            data-currency={currency}
+                            aria-pressed={
+                                currency === defaultCurrency
+                                    ? "true"
+                                    : "false"
+                            }
+                            class={`px-4 py-1.5 text-sm font-bold rounded-full transition-colors cursor-pointer ${
+                                currency === defaultCurrency
+                                    ? "bg-white dark:bg-slate-900 text-slate-900 dark:text-white shadow"
+                                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+                            }`}
+                        >
+                            {currency.toUpperCase()}
+                        </button>
+                    ))
+                }
+            </div>
+        </div>
+
         <div
             class="grid md:grid-cols-3 gap-8 lg:gap-10 max-w-6xl mx-auto items-center"
         >
             {
-                plans.map((plan) => (
+                resolvedPlans.map((plan) => (
                     <div
                         class={`relative p-8 rounded-2xl transition-all duration-300 ${
                             plan.isPopular
@@ -171,7 +144,7 @@ const plans = [
                     >
                         {plan.isPopular && (
                             <div class="absolute -top-4 left-1/2 -translate-x-1/2 bg-primary-500 text-white px-4 py-1 rounded-full text-sm font-bold shadow-lg">
-                                Most Popular
+                                {t.popularBadge}
                             </div>
                         )}
 
@@ -181,15 +154,34 @@ const plans = [
                             </h3>
                             <div class="flex items-baseline justify-center gap-1">
                                 <span class="text-4xl font-extrabold text-slate-900 dark:text-white">
-                                    {plan.price}
+                                    <span
+                                        data-price-usd
+                                        class={
+                                            defaultCurrency === "usd"
+                                                ? ""
+                                                : "hidden"
+                                        }
+                                    >
+                                        {plan.price.usd}
+                                    </span>
+                                    <span
+                                        data-price-twd
+                                        class={
+                                            defaultCurrency === "twd"
+                                                ? ""
+                                                : "hidden"
+                                        }
+                                    >
+                                        {plan.price.twd}
+                                    </span>
                                 </span>
                                 <span class="text-slate-500 dark:text-slate-400">
-                                    {plan.period}
+                                    {plan.per}
                                 </span>
                             </div>
                         </div>
 
-                        <ul class="space-y-4 mb-8">
+                        <ul class="space-y-4 mb-6">
                             {plan.features.map((feature) => (
                                 <li class="flex items-start gap-3 text-slate-600 dark:text-slate-300">
                                     <svg
@@ -210,6 +202,24 @@ const plans = [
                             ))}
                         </ul>
 
+                        {plan.examples.length > 0 && (
+                            <div class="mb-8 pt-4 border-t border-slate-100 dark:border-slate-800">
+                                <p class="text-xs uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2">
+                                    {t.examplesLabel}
+                                </p>
+                                <div class="flex flex-wrap gap-2">
+                                    {plan.examples.map((example) => (
+                                        <a
+                                            href={example.href}
+                                            class="text-xs px-2.5 py-1 rounded-full bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 hover:underline transition-colors"
+                                        >
+                                            {example.title}
+                                        </a>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
                         <a
                             href="#contact"
                             class={`block w-full py-3 px-6 rounded-lg text-center font-bold transition-colors ${
@@ -218,7 +228,7 @@ const plans = [
                                     : "bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-900 dark:text-white"
                             }`}
                         >
-                            {plan.buttonText}
+                            {plan.cta}
                         </a>
                     </div>
                 ))
@@ -263,5 +273,69 @@ const plans = [
                 </span>
             </p>
         </div>
-    </div>
+    </currency-toggle>
 </section>
+
+<script>
+    import { preferredCurrency, type Currency } from "@/stores/pricing.store";
+
+    // 幣別切換 Web Component：偏好存進 persistentAtom（跨頁、重載存活），
+    // 未選擇時採語系預設。訂閱於 disconnectedCallback 退訂。
+    class CurrencyToggle extends HTMLElement {
+        private unsubscribe?: () => void;
+
+        connectedCallback() {
+            const fallback: Currency =
+                this.dataset.defaultCurrency === "twd" ? "twd" : "usd";
+            const buttons =
+                this.querySelectorAll<HTMLButtonElement>("[data-currency]");
+
+            buttons.forEach((btn) => {
+                btn.addEventListener("click", () => {
+                    preferredCurrency.set(btn.dataset.currency as Currency);
+                });
+            });
+
+            // 與伺服器端渲染的按鈕樣式保持一致
+            const ACTIVE = [
+                "bg-white",
+                "dark:bg-slate-900",
+                "text-slate-900",
+                "dark:text-white",
+                "shadow",
+            ];
+            const INACTIVE = [
+                "text-slate-500",
+                "dark:text-slate-400",
+                "hover:text-slate-700",
+                "dark:hover:text-slate-200",
+            ];
+
+            this.unsubscribe = preferredCurrency.subscribe((stored) => {
+                const currency = stored || fallback;
+
+                this.querySelectorAll<HTMLElement>("[data-price-usd]").forEach(
+                    (el) => el.classList.toggle("hidden", currency !== "usd"),
+                );
+                this.querySelectorAll<HTMLElement>("[data-price-twd]").forEach(
+                    (el) => el.classList.toggle("hidden", currency !== "twd"),
+                );
+
+                buttons.forEach((btn) => {
+                    const active = btn.dataset.currency === currency;
+                    btn.setAttribute("aria-pressed", String(active));
+                    btn.classList.remove(...(active ? INACTIVE : ACTIVE));
+                    btn.classList.add(...(active ? ACTIVE : INACTIVE));
+                });
+            });
+        }
+
+        disconnectedCallback() {
+            this.unsubscribe?.();
+        }
+    }
+
+    if (!customElements.get("currency-toggle")) {
+        customElements.define("currency-toggle", CurrencyToggle);
+    }
+</script>

--- a/src/components/sections/Pricing.astro
+++ b/src/components/sections/Pricing.astro
@@ -90,7 +90,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
     >
         <div class="text-center mb-12">
             <h2
-                class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white tracking-tight mb-6 drop-shadow-sm transition-colors"
+                class="text-3xl md:text-4xl font-bold font-mono text-slate-900 dark:text-white tracking-tight mb-6 drop-shadow-sm transition-colors"
             >
                 {t.title}
             </h2>

--- a/src/components/sections/Pricing.astro
+++ b/src/components/sections/Pricing.astro
@@ -138,7 +138,7 @@ const t = translations[lang as keyof typeof translations] || translations.en;
                     <div
                         class={`relative p-8 rounded-2xl transition-all duration-300 ${
                             plan.isPopular
-                                ? "bg-white dark:bg-slate-900 shadow-2xl scale-105 border-2 border-primary-500 z-10"
+                                ? "bg-white dark:bg-slate-900 shadow-2xl md:scale-105 border-2 border-primary-500 z-10"
                                 : "bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800 hover:shadow-xl"
                         }`}
                     >

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -61,17 +61,23 @@ const serviceMeta = [
     {
         exampleProjectId: "kairos-website",
         exampleTheme: "VisualDesigner",
+        iconColor:
+            "bg-pink-100 dark:bg-pink-900/30 text-pink-600 dark:text-pink-400",
         iconPath:
             "M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
     },
     {
         exampleProjectId: "aoi-vision-platform",
         exampleTheme: "SoftwareEngineer",
+        iconColor:
+            "bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400",
         iconPath: "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4",
     },
     {
         exampleProjectId: "klab-design-system",
         exampleTheme: "UXUIDesigner",
+        iconColor:
+            "bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400",
         iconPath:
             "M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z",
     },
@@ -100,6 +106,7 @@ const services = serviceMeta.map((meta, index) => {
     return {
         ...serviceCopy[index],
         iconPath: meta.iconPath,
+        iconColor: meta.iconColor,
         example: example
             ? {
                   title: example.title,
@@ -132,7 +139,9 @@ const services = serviceMeta.map((meta, index) => {
             {
                 services.map((s) => (
                     <div class="bg-slate-50 dark:bg-slate-800 rounded-xl p-8 border border-slate-100 dark:border-slate-700 hover:shadow-lg transition-all duration-300 group">
-                        <div class="w-12 h-12 bg-primary-100 dark:bg-primary-900/30 rounded-lg flex items-center justify-center text-primary-600 dark:text-primary-400 mb-6 group-hover:scale-110 transition-transform duration-300">
+                        <div
+                            class={`w-12 h-12 rounded-lg flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 ${s.iconColor}`}
+                        >
                             <svg
                                 class="w-6 h-6"
                                 fill="none"

--- a/src/components/sections/Services.astro
+++ b/src/components/sections/Services.astro
@@ -1,5 +1,13 @@
 ---
+import { getEntry } from "astro:content";
+import type { ProjectData } from "@/stores/portfolio.store";
+
 const lang = Astro.currentLocale || "en";
+
+// Each service links to a real project from the projects collection
+// as proof of work, pointed at the explorer lens that shows it best.
+const projectsEntry = await getEntry("projects", `projects-${lang}`);
+const projects: ProjectData[] = projectsEntry?.data ?? [];
 
 const translations = {
     en: {
@@ -22,6 +30,7 @@ const translations = {
             "Move beyond chaos with a centralized design language. We build comprehensive UI kits and component libraries that bridge the gap between design and development, accelerating future feature rollouts while maintaining perfect consistency.",
         learnMore: "Learn More",
         showLess: "Show Less",
+        exampleLabel: "Real example:",
     },
     "zh-tw": {
         title: "專業領域",
@@ -40,33 +49,65 @@ const translations = {
             "透過集中化的設計語言擺脫混亂。我們建立全面的 UI 套件與元件庫，縮短設計與開發之間的差距，在加速未來功能推出的同時，保持完美的品牌一致性。",
         learnMore: "了解更多",
         showLess: "收起",
+        exampleLabel: "實際案例：",
     },
 };
 
 const t = translations[lang as keyof typeof translations] || translations.en;
 
-const services = [
+// exampleProjectId references the projects collection; exampleTheme picks
+// the explorer lens that presents that project best
+const serviceMeta = [
+    {
+        exampleProjectId: "kairos-website",
+        exampleTheme: "VisualDesigner",
+        iconPath:
+            "M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
+    },
+    {
+        exampleProjectId: "aoi-vision-platform",
+        exampleTheme: "SoftwareEngineer",
+        iconPath: "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4",
+    },
+    {
+        exampleProjectId: "klab-design-system",
+        exampleTheme: "UXUIDesigner",
+        iconPath:
+            "M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z",
+    },
+];
+
+const serviceCopy = [
     {
         title: t.service1Title,
         desc: t.service1Desc,
         details: t.service1Details,
-        iconPath:
-            "M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z",
     },
     {
         title: t.service2Title,
         desc: t.service2Desc,
         details: t.service2Details,
-        iconPath: "M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4",
     },
     {
         title: t.service3Title,
         desc: t.service3Desc,
         details: t.service3Details,
-        iconPath:
-            "M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z",
     },
 ];
+
+const services = serviceMeta.map((meta, index) => {
+    const example = projects.find((p) => p.id === meta.exampleProjectId);
+    return {
+        ...serviceCopy[index],
+        iconPath: meta.iconPath,
+        example: example
+            ? {
+                  title: example.title,
+                  href: `/${lang}/explore/portfolio/${meta.exampleTheme}`,
+              }
+            : null,
+    };
+});
 ---
 
 <section
@@ -141,6 +182,20 @@ const services = [
                                 {s.details}
                             </div>
                         </details>
+
+                        {s.example && (
+                            <div class="mt-6 pt-4 border-t border-slate-100 dark:border-slate-700 text-sm">
+                                <span class="text-slate-400 dark:text-slate-500 text-xs uppercase tracking-wider">
+                                    {t.exampleLabel}
+                                </span>
+                                <a
+                                    href={s.example.href}
+                                    class="ml-1 text-primary-600 dark:text-primary-400 font-medium hover:underline"
+                                >
+                                    {s.example.title}
+                                </a>
+                            </div>
+                        )}
                     </div>
                 ))
             }

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -118,6 +118,28 @@ const projectsCollection = defineCollection({
     })),
 });
 
+// ── Pricing collection ──
+// Locale-split like themes/projects (pricing-en.json / pricing-zh-tw.json).
+// Both currencies stored per plan (display strings, not converted rates);
+// exampleProjectIds cross-reference the projects collection.
+
+const pricingCollection = defineCollection({
+    type: 'data',
+    schema: z.array(z.object({
+        id: z.string(),                 // stable across locales
+        title: z.string(),
+        price: z.object({
+            usd: z.string(),            // e.g. "$1,500"
+            twd: z.string(),            // e.g. "NT$45,000"
+        }),
+        per: z.string(),                // e.g. "/ starting"
+        features: z.array(z.string()),
+        cta: z.string(),
+        isPopular: z.boolean().default(false),
+        exampleProjectIds: z.array(z.string()).optional(),
+    })),
+});
+
 const blogCollection = defineCollection({
     type: 'content',
     schema: z.object({
@@ -140,4 +162,5 @@ export const collections = {
     'themes': themeCollection,
     'blog': blogCollection,
     'projects': projectsCollection,
+    'pricing': pricingCollection,
 };

--- a/src/content/pricing/pricing-en.json
+++ b/src/content/pricing/pricing-en.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": "landing-page",
+        "title": "Landing Page",
+        "price": { "usd": "$1,500", "twd": "NT$45,000" },
+        "per": "/ starting",
+        "features": [
+            "High-Converting Single Page",
+            "Fully Mobile Responsive",
+            "Contact Form & Lead Gen",
+            "5-7 Day Turnaround"
+        ],
+        "cta": "Start Project",
+        "isPopular": false,
+        "exampleProjectIds": ["kairos-website"]
+    },
+    {
+        "id": "business-website",
+        "title": "Business Website",
+        "price": { "usd": "$4,800", "twd": "NT$120,000" },
+        "per": "/ starting",
+        "features": [
+            "Up to 8 Custom Pages",
+            "Easy-to-use CMS (Manage Content)",
+            "Technical SEO & Analytics",
+            "Handover Training & Docs"
+        ],
+        "cta": "Choose This Plan",
+        "isPopular": true,
+        "exampleProjectIds": ["klab-design-system"]
+    },
+    {
+        "id": "custom-web-app",
+        "title": "Custom Web App",
+        "price": { "usd": "$10k+", "twd": "NT$300,000+" },
+        "per": "/ project",
+        "features": [
+            "React / Next.js Architecture",
+            "Database & Auth Integration",
+            "Custom API Development",
+            "30 Days Post-Launch Support"
+        ],
+        "cta": "Get a Quote",
+        "isPopular": false,
+        "exampleProjectIds": ["aoi-vision-platform", "smart-factory-cloud-migration"]
+    }
+]

--- a/src/content/pricing/pricing-zh-tw.json
+++ b/src/content/pricing/pricing-zh-tw.json
@@ -1,0 +1,47 @@
+[
+    {
+        "id": "landing-page",
+        "title": "形象著陸頁",
+        "price": { "usd": "$1,500", "twd": "NT$45,000" },
+        "per": "/ 起",
+        "features": [
+            "高轉換率單頁設計",
+            "完全響應式 (手機友善)",
+            "聯絡表單與潛在客戶收集",
+            "5-7 天快速交付"
+        ],
+        "cta": "開始專案",
+        "isPopular": false,
+        "exampleProjectIds": ["kairos-website"]
+    },
+    {
+        "id": "business-website",
+        "title": "商業形象網站",
+        "price": { "usd": "$4,800", "twd": "NT$120,000" },
+        "per": "/ 起",
+        "features": [
+            "最多 8 個客製化頁面",
+            "易用的後台 (內容管理)",
+            "技術 SEO 與分析設定",
+            "移交教育訓練與文件"
+        ],
+        "cta": "選擇此方案",
+        "isPopular": true,
+        "exampleProjectIds": ["klab-design-system"]
+    },
+    {
+        "id": "custom-web-app",
+        "title": "客製化 Web App",
+        "price": { "usd": "$10k+", "twd": "NT$300,000+" },
+        "per": "/ 專案",
+        "features": [
+            "React / Next.js 架構",
+            "資料庫與會員驗證整合",
+            "客製化 API 開發",
+            "上線後 30 天技術支援"
+        ],
+        "cta": "索取報價",
+        "isPopular": false,
+        "exampleProjectIds": ["aoi-vision-platform", "smart-factory-cloud-migration"]
+    }
+]

--- a/src/stores/pricing.store.ts
+++ b/src/stores/pricing.store.ts
@@ -1,0 +1,10 @@
+import { persistentAtom } from '@nanostores/persistent';
+
+export type Currency = 'usd' | 'twd';
+
+// 使用者偏好的報價幣別，跨頁與重新載入存活。
+// 空字串代表尚未選擇：客戶端會改用語系預設（en → usd、zh-tw → twd）。
+export const preferredCurrency = persistentAtom<Currency | ''>(
+    'kairos-currency',
+    '',
+);


### PR DESCRIPTION
## Summary

Extends the real-data philosophy from PR #17 to the homepage, plus a screenshot-verified visual polish pass. Every section now either renders from a content collection or cites real projects as proof of work.

### Interactive Capability Showcase (`Portfolio.astro`)
- Theme chips per category come from the **themes collection** (localized names, deep links to each layout) with live theme counts
- The portfolio card previews **real heroImages from the projects collection** as a mini waterfall; the other four categories get pure CSS skeleton previews of their signature layouts
- `showcase-rotator` Custom Element cycles the highlighted chip every 3s (hover pauses; timer cleaned up on disconnect)
- Fifth card now spans both columns as a horizontal card — no more orphaned half-row

### Transparent Investment (`Pricing.astro`)
- New **pricing collection**: locale-split, dual-currency display prices (TWD anchored to 2026 Taiwan market rates: NT$45,000 / NT$120,000 / NT$300,000+)
- Each plan cites real projects from the **projects collection**, deep linked to the explorer
- `currency-toggle` Custom Element switches USD/TWD, persisting the preference in a `persistentAtom` (locale defaults: en→USD, zh-tw→TWD)
- Fixes two pre-existing bugs: hardcoded-English "Most Popular" badge; middle plan's CTA button showing the badge text

### Our Expertise (`Services.astro`)
- Each service cites a real project as proof of work
- Per-card icon accent colors (pink/blue/indigo)

### Cross-cutting
- `astro check` now reports **0 errors** (fixed the last 3 `translations[lang]` indexing errors in Hero/Contact/Footer)
- Unified section H2 typography (`font-mono text-3xl/4xl`)
- Hero: availability status pill + brand-gradient primary CTA
- Dark mode section backgrounds alternate 900/950 cleanly
- Corrected LinkedIn profile URL in About and Contact
- RWD verified at 390px: no horizontal overflow; popular-card scale scoped to desktop

## Verification

- Full-page screenshots reviewed in all four combinations (desktop/mobile × light/dark)
- Both locales verified: 25 theme chips, real project images, currency defaults, localized badges
- `npm run build` green; `astro check` 0 errors; zero new runtime dependencies

## Known follow-up

- About section photo is still a picsum placeholder — needs a real photo (asset pipeline batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)