### PR TITLE
feat(blog): editorial article layout + section rail (closes #19)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,15 @@ export default defineConfig({
   adapter: cloudflare(),
   site: 'https://kairos-559.pages.dev',
   integrations: [tailwind(), sitemap()],
+  markdown: {
+    // Dual light/dark Shiki themes — the `.dark` class strategy switches
+    // between them via CSS variables (see src/styles/global.css).
+    // Astro already auto-adds `id`s to headings, so no rehype-slug needed.
+    shikiConfig: {
+      themes: { light: 'github-light', dark: 'github-dark' },
+      wrap: true,
+    },
+  },
   i18n: {
     defaultLocale: "en",
     locales: ["en", "zh-tw"],

--- a/docs/specs/blog-rendering-redesign-spec.md
+++ b/docs/specs/blog-rendering-redesign-spec.md
@@ -1,0 +1,107 @@
+# Design Spec — Blog Article Rendering Redesign
+
+> **Issue:** #19 · **Scope:** blog article + index pages, type tokens, Shiki config.
+> **Repo:** `Kai-Digital-Lab/kairos` · read `CLAUDE.md` before touching anything.
+
+---
+
+## 1. Objective
+
+Give long-form bilingual (en / zh-tw) blog reading a distinctive **editorial identity** without
+adding any runtime framework and without breaking the zero-runtime / View-Transition conventions.
+
+The old article page read as generic: greyscale `prose-slate`, a centred narrow column, headings
+sharing the body family, no Shiki theme, and a scroll-progress listener that leaked across
+View-Transition navigations.
+
+**Definition of done in one line:** a reader lands on a post and immediately recognises it as *this*
+site — a Technical Director's editorial — with a working, non-leaking section rail.
+
+---
+
+## 2. Design concept — "The Technical Director's editorial layout"
+
+Echo the author's 技術型導演 positioning and the site's engineering-proud tone by making
+**monospace the structural accent** (section numbers, eyebrows, meta line). This deliberately avoids
+the common AI-design defaults (cream + high-contrast serif + terracotta). Colour extends the existing
+`primary` + `purple` gradient — no new palette.
+
+### Type pairing (confirmed)
+
+| Role | Face | Loading | Rationale |
+|---|---|---|---|
+| **Display** (H1, headings) | Space Grotesk (variable) | Latin webfont, blog pages only | Geometric, engineering-toned, has personality without the serif/cream cluster. |
+| **Accent** (numbers, eyebrow, meta) | Space Mono | Latin webfont, blog pages only | Same lineage as Space Grotesk → coherent pairing; mono-as-structure fits the tone. |
+| **Body** | system sans + CJK fallback | no download | `sans` token enriched with PingFang TC / Microsoft JhengHei / Noto Sans TC. |
+
+**Why no CJK webfont:** Traditional-Chinese webfonts are heavy (hundreds of KB even subset). System
+CJK fonts render zh-tw well and cost nothing — the leanness that the zero-runtime philosophy demands.
+The `sans` enrichment is applied globally (system fonts only, no download), improving zh-tw everywhere.
+
+Tokens live in `tailwind.config.mjs` as **new** `display` / `accent` keys — the global `mono` token is
+left untouched, so the site header logo and other existing `font-mono` usages are unaffected.
+
+---
+
+## 3. Layout
+
+- **Asymmetric two-column grid** at `lg`: `grid-cols-[13rem_minmax(0,1fr)]`, collapses to one column below.
+- **Left-aligned display H1** (not centred), mono eyebrow above, mono meta line below
+  (`date / author / reading time`, bilingual). Reading time is computed inline from `post.body`
+  (Latin words ÷ 200 + CJK glyphs ÷ 400).
+- **Drop-cap** on the opening paragraph via a Tailwind arbitrary variant on the prose container.
+- **Reading measure** replaces `max-w-none`: `70ch` for Latin, `34em` (narrower) for CJK.
+
+---
+
+## 4. Signature section rail
+
+- Auto-generated **server-side** from `render(post).headings` (h2/h3), numbered `01 / 02 …` in the
+  accent font. Numbering is justified because posts are genuinely sequential (`## 第一步…`, `## 第二步…`).
+- **Heading anchors:** Astro already auto-adds matching `id`s to rendered headings (verified in the
+  build output, incl. CJK slugs) — so **`rehype-slug` is NOT needed**; the only new deps are the two
+  `@fontsource` packages.
+- Rail links are **real anchors** (`<a href="#slug">`) — keyboard- and no-JS-friendly.
+- **Sticky** at `top-24` to clear the `fixed h-16` header.
+- **Integrated reading progress:** the standalone top scroll-bar is folded in. One passive scroll
+  handler drives both the rail's progress fill + `%` label (desktop) and a thin top bar (mobile).
+- Rail is `hidden lg:block`; on mobile the top bar (`lg:hidden`) takes over.
+
+### Lifecycle — `<article-rail>` Custom Element
+
+The rail is a native Custom Element mirroring the established pattern
+(`FullBleedCarouselLayout.astro`, `ProjectModal.astro`): set up the `IntersectionObserver`
+(active-section highlight, lifted from `Header.astro` scroll-spy) and the passive scroll listener in
+`connectedCallback`; `observer.disconnect()` + `removeEventListener` in `disconnectedCallback`.
+Because `<ClientRouter />` fires `connected`/`disconnected` on every View-Transition swap, listeners
+**never accumulate** — this replaces (and fixes) the old leaking `astro:page-load` scroll listener.
+
+---
+
+## 5. Markdown polish
+
+- `markdown.shikiConfig` set to dual themes (`github-light` / `github-dark`), `wrap: true`.
+- The conflicting `prose-pre:bg-slate-900` is removed so Shiki controls the code background; dark mode
+  swaps to the `--shiki-dark` CSS variables via `html.dark .astro-code` (class strategy) in `global.css`.
+- Inline code uses the accent font; blockquotes use the `primary` accent, de-italicised.
+
+---
+
+## 6. Accessibility
+
+- `prefers-reduced-motion` disables the global smooth-scroll (`global.css`).
+- Rail links are real anchors with `aria-current` on the active section; keyboard focus visible.
+- Contrast holds AA in light and dark.
+
+---
+
+## 7. Acceptance criteria (from issue #19)
+
+- [x] `npm run build` green; `npx astro check` no new errors.
+- [x] Not greyscale-only: display / accent / body roles visibly distinct; accent used with restraint.
+- [x] Rail auto-generates from headings, tracks active section, integrates progress, collapses on mobile.
+- [x] Renders in en + zh-tw; CJK glyphs intact; comfortable measure.
+- [x] Scroll/rail listeners survive a View Transition and do not leak; no `DOMContentLoaded`.
+- [x] Shiki dual theme applied; code consistent light + dark.
+- [x] Zero new runtime frameworks; client JS stays lean (only the two `@fontsource` build deps added).
+- [x] a11y floor: reduced-motion respected, focus visible, contrast AA, rail links are real anchors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@astrojs/cloudflare": "^12.6.12",
         "@astrojs/sitemap": "^3.6.0",
         "@astrojs/tailwind": "^6.0.2",
+        "@fontsource-variable/space-grotesk": "^5.2.10",
+        "@fontsource/space-mono": "^5.2.9",
         "@nanostores/persistent": "^1.2.0",
         "astro": "^5.16.6",
         "nanostores": "^1.1.0",
@@ -914,6 +916,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-mono": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-mono/-/space-mono-5.2.9.tgz",
+      "integrity": "sha512-b61faFOHEISQ/pD25G+cfGY9o/WW6lRv6hBQQfpWvEJ4y1V+S4gmth95EVyBE2VL3qDYHeVQ8nBzrplzdXTDDg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@astrojs/cloudflare": "^12.6.12",
     "@astrojs/sitemap": "^3.6.0",
     "@astrojs/tailwind": "^6.0.2",
+    "@fontsource-variable/space-grotesk": "^5.2.10",
+    "@fontsource/space-mono": "^5.2.9",
     "@nanostores/persistent": "^1.2.0",
     "astro": "^5.16.6",
     "nanostores": "^1.1.0",

--- a/src/pages/[lang]/blog/[...slug].astro
+++ b/src/pages/[lang]/blog/[...slug].astro
@@ -2,6 +2,13 @@
 import { getCollection, render } from "astro:content";
 import PageLayout from "@/layouts/PageLayout.astro";
 
+// Editorial type — Latin webfonts loaded on blog pages only (CJK uses
+// system fallback via the `sans` token). Unused subsets are lazy per
+// unicode-range, so only latin is actually downloaded.
+import "@fontsource-variable/space-grotesk";
+import "@fontsource/space-mono/latin-400.css";
+import "@fontsource/space-mono/latin-700.css";
+
 export const prerender = true;
 
 export async function getStaticPaths() {
@@ -19,7 +26,12 @@ if (!post) {
     return Astro.redirect("/404");
 }
 
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
+
+// Section rail — built server-side from Astro's heading extraction.
+// Astro auto-adds matching `id`s to the rendered headings (verified),
+// so no rehype-slug is needed. Only h2/h3 feed the rail.
+const railHeadings = headings.filter((h) => h.depth === 2 || h.depth === 3);
 
 // Find translated version via translationKey
 let translatedPost = null;
@@ -34,6 +46,14 @@ if (post.data.translationKey) {
 
 const targetLang = lang === "en" ? "zh-tw" : "en";
 
+// Reading time — Latin words at ~200 wpm + CJK glyphs at ~400 cpm.
+const cjkChars = (post.body.match(/[㐀-鿿]/g) || []).length;
+const latinWords = post.body
+    .replace(/[㐀-鿿]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+const minutes = Math.max(1, Math.round(latinWords / 200 + cjkChars / 400));
+
 // SEO Logic
 const isDraft = post.data.isDraft;
 const robots = isDraft ? "noindex, nofollow" : "index, follow";
@@ -44,15 +64,25 @@ const translations = {
     en: {
         draft: "Draft Preview",
         readIn: "閱讀中文版",
+        eyebrow: "Journal",
+        contents: "Contents",
+        readTime: `${minutes} min read`,
     },
     "zh-tw": {
         draft: "草稿預覽",
         readIn: "Read in English",
+        eyebrow: "筆記",
+        contents: "目錄",
+        readTime: `${minutes} 分鐘閱讀`,
     },
 };
 
-const t =
-    translations[lang as keyof typeof translations] || translations.en;
+const t = translations[lang as keyof typeof translations] || translations.en;
+
+const eyebrow = post.data.tags?.[0] || t.eyebrow;
+
+// Reading measure — narrower for CJK than for Latin.
+const measure = lang === "zh-tw" ? "max-w-[34em]" : "max-w-[70ch]";
 
 // Toggle URL: link to translated post if exists, otherwise fallback to blog list
 const toggleUrl = translatedPost
@@ -68,146 +98,293 @@ const toggleUrl = translatedPost
     article={true}
     toggleUrl={toggleUrl}
 >
-    <!-- Progress Indicator (Minimalist) -->
-    <div
-        class="fixed top-0 left-0 w-full h-1 bg-slate-100 dark:bg-slate-800 z-50"
-    >
+    <article-rail>
+        <!-- Mobile / narrow progress bar (rail takes over on lg) -->
         <div
-            class="h-full bg-primary-600 w-0 transition-all duration-150 ease-out"
-            id="scroll-progress"
+            class="fixed top-0 left-0 w-full h-1 bg-slate-100 dark:bg-slate-800 z-50 lg:hidden"
         >
-        </div>
-    </div>
-
-    <article class="py-20 bg-white dark:bg-slate-900 min-h-screen">
-        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-            <!-- Header -->
-            <header class="mb-12 text-center">
-                {
-                    isDraft && (
-                        <span class="inline-block px-3 py-1 mb-4 text-xs font-bold tracking-wider text-amber-500 uppercase bg-amber-100 dark:bg-amber-900/30 rounded-full border border-amber-200 dark:border-amber-700">
-                            {t.draft}
-                        </span>
-                    )
-                }
-                <div
-                    class="flex items-center justify-center gap-2 mb-6 text-sm text-slate-500 dark:text-slate-400 font-mono"
-                >
-                    <time datetime={post.data.pubDate.toISOString()}>
-                        {
-                            post.data.pubDate.toLocaleDateString(dateLocale, {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                            })
-                        }
-                    </time>
-                    <span>•</span>
-                    <span>{post.data.author}</span>
-                </div>
-
-                <h1
-                    class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white mb-6 leading-tight"
-                >
-                    {post.data.title}
-                </h1>
-
-                <p
-                    class="text-xl text-slate-600 dark:text-slate-300 leading-relaxed max-w-2xl mx-auto"
-                >
-                    {post.data.description}
-                </p>
-
-                <!-- Tags -->
-                {
-                    post.data.tags && (
-                        <div class="flex flex-wrap justify-center gap-2 mt-8">
-                            {post.data.tags.map((tag) => (
-                                <span class="px-3 py-1 text-sm text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-md border border-slate-200 dark:border-slate-700">
-                                    #{tag}
-                                </span>
-                            ))}
-                        </div>
-                    )
-                }
-
-                <!-- Translation Link -->
-                {
-                    translatedPost && (
-                        <div class="mt-6">
-                            <a
-                                href={`/${targetLang}/blog/${translatedPost.slug}`}
-                                class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors border border-slate-200 dark:border-slate-700"
-                            >
-                                <svg
-                                    class="w-4 h-4"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                    stroke-width="1.5"
-                                    stroke="currentColor"
-                                >
-                                    <path
-                                        stroke-linecap="round"
-                                        stroke-linejoin="round"
-                                        d="m10.5 21 5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 0 1 6-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 0 1-3.827-5.802"
-                                    />
-                                </svg>
-                                {t.readIn}
-                            </a>
-                        </div>
-                    )
-                }
-            </header>
-
-            <!-- Divider -->
-            <hr class="border-slate-200 dark:border-slate-800 mb-12" />
-
-            <!-- Content -->
             <div
-                class="prose prose-slate dark:prose-invert prose-lg max-w-none
-                prose-headings:font-bold prose-headings:text-slate-900 dark:prose-headings:text-white
-                prose-a:text-primary-600 dark:prose-a:text-primary-400 prose-a:no-underline hover:prose-a:underline
-                prose-code:text-pink-600 dark:prose-code:text-pink-400 prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:before:content-none prose-code:after:content-none
-                prose-pre:bg-slate-900 dark:prose-pre:bg-slate-950 prose-pre:border prose-pre:border-slate-800
-                prose-blockquote:border-l-primary-500 prose-blockquote:bg-slate-50 dark:prose-blockquote:bg-slate-900/50 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:rounded-r-lg"
+                class="h-full bg-primary-600 w-0 transition-[width] duration-150 ease-out"
+                data-progress-bar
             >
-                <Content />
             </div>
-
-            <!-- Medium Syndication Link -->
-            {
-                post.data.mediumUrl && (
-                    <div class="mt-12 pt-8 border-t border-slate-200 dark:border-slate-800">
-                        <a
-                            href={post.data.mediumUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
-                        >
-                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
-                            </svg>
-                            Also available on Medium
-                        </a>
-                    </div>
-                )
-            }
         </div>
-    </article>
+
+        <article
+            class="py-16 sm:py-20 bg-white dark:bg-slate-900 min-h-screen"
+        >
+            <div
+                class="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 lg:grid lg:grid-cols-[13rem_minmax(0,1fr)] lg:gap-12"
+            >
+                <!-- Signature section rail (desktop) -->
+                <aside class="hidden lg:block">
+                    <div class="sticky top-24">
+                        {
+                            railHeadings.length > 0 && (
+                                <nav aria-label={t.contents}>
+                                    <p class="font-accent text-[0.7rem] uppercase tracking-[0.2em] text-slate-400 dark:text-slate-500 mb-4">
+                                        {t.contents}
+                                    </p>
+                                    <ol class="border-l border-slate-200 dark:border-slate-800">
+                                        {railHeadings.map((h, i) => (
+                                            <li>
+                                                <a
+                                                    href={`#${h.slug}`}
+                                                    data-rail-link={h.slug}
+                                                    class:list={[
+                                                        "group flex gap-2.5 -ml-px border-l-2 border-transparent py-1 text-sm leading-snug text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors",
+                                                        h.depth === 3 ? "pl-8" : "pl-4",
+                                                    ]}
+                                                >
+                                                    <span class="font-accent text-xs text-slate-300 dark:text-slate-600 group-hover:text-primary-500 tabular-nums">
+                                                        {String(i + 1).padStart(2, "0")}
+                                                    </span>
+                                                    <span>{h.text}</span>
+                                                </a>
+                                            </li>
+                                        ))}
+                                    </ol>
+                                </nav>
+                            )
+                        }
+
+                        <!-- Integrated reading progress -->
+                        <div class="mt-8 flex items-center gap-3">
+                            <div
+                                class="h-1 flex-1 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden"
+                            >
+                                <div
+                                    class="h-full w-0 bg-gradient-to-r from-primary-500 to-purple-500"
+                                    data-progress-bar
+                                >
+                                </div>
+                            </div>
+                            <span
+                                class="font-accent text-xs text-slate-400 dark:text-slate-500 tabular-nums"
+                                data-progress-label>0%</span
+                            >
+                        </div>
+                    </div>
+                </aside>
+
+                <!-- Content column -->
+                <div class="min-w-0">
+                    <header class="mb-10">
+                        {
+                            isDraft && (
+                                <span class="inline-block px-3 py-1 mb-5 text-xs font-bold tracking-wider text-amber-500 uppercase bg-amber-100 dark:bg-amber-900/30 rounded-full border border-amber-200 dark:border-amber-700">
+                                    {t.draft}
+                                </span>
+                            )
+                        }
+
+                        <!-- Eyebrow (mono structural accent) -->
+                        <p
+                            class="font-accent text-xs uppercase tracking-[0.2em] text-primary-600 dark:text-primary-400 mb-4"
+                        >
+                            {eyebrow}
+                        </p>
+
+                        <!-- Display H1 (left-aligned) -->
+                        <h1
+                            class="font-display text-4xl md:text-5xl font-bold text-slate-900 dark:text-white mb-5 leading-[1.1] tracking-tight text-balance"
+                        >
+                            {post.data.title}
+                        </h1>
+
+                        <!-- Mono meta line -->
+                        <div
+                            class="flex flex-wrap items-center gap-x-3 gap-y-1 font-accent text-sm text-slate-500 dark:text-slate-400"
+                        >
+                            <time datetime={post.data.pubDate.toISOString()}>
+                                {
+                                    post.data.pubDate.toLocaleDateString(dateLocale, {
+                                        year: "numeric",
+                                        month: "long",
+                                        day: "numeric",
+                                    })
+                                }
+                            </time>
+                            <span class="text-slate-300 dark:text-slate-600">/</span>
+                            <span>{post.data.author}</span>
+                            <span class="text-slate-300 dark:text-slate-600">/</span>
+                            <span>{t.readTime}</span>
+                        </div>
+
+                        <!-- Standfirst -->
+                        <p
+                            class="mt-6 text-xl text-slate-600 dark:text-slate-300 leading-relaxed max-w-2xl"
+                        >
+                            {post.data.description}
+                        </p>
+
+                        <!-- Tags -->
+                        {
+                            post.data.tags && (
+                                <div class="flex flex-wrap gap-2 mt-6">
+                                    {post.data.tags.map((tag) => (
+                                        <span class="font-accent px-2.5 py-0.5 text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-800 rounded border border-slate-200 dark:border-slate-700">
+                                            #{tag}
+                                        </span>
+                                    ))}
+                                </div>
+                            )
+                        }
+
+                        <!-- Translation Link -->
+                        {
+                            translatedPost && (
+                                <div class="mt-6">
+                                    <a
+                                        href={`/${targetLang}/blog/${translatedPost.slug}`}
+                                        class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors border border-slate-200 dark:border-slate-700"
+                                    >
+                                        <svg
+                                            class="w-4 h-4"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke-width="1.5"
+                                            stroke="currentColor"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                d="m10.5 21 5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 0 1 6-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 0 1-3.827-5.802"
+                                            />
+                                        </svg>
+                                        {t.readIn}
+                                    </a>
+                                </div>
+                            )
+                        }
+                    </header>
+
+                    <!-- Divider -->
+                    <hr class="border-slate-200 dark:border-slate-800 mb-10" />
+
+                    <!-- Content -->
+                    <div
+                        data-article-body
+                        class:list={[
+                            "prose prose-slate dark:prose-invert prose-lg",
+                            measure,
+                            "prose-headings:font-display prose-headings:font-bold prose-headings:tracking-tight prose-headings:text-slate-900 dark:prose-headings:text-white prose-headings:scroll-mt-24",
+                            "prose-a:text-primary-600 dark:prose-a:text-primary-400 prose-a:no-underline hover:prose-a:underline",
+                            "prose-code:font-accent prose-code:text-pink-600 dark:prose-code:text-pink-400 prose-code:bg-slate-100 dark:prose-code:bg-slate-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:before:content-none prose-code:after:content-none",
+                            "prose-pre:border prose-pre:border-slate-200 dark:prose-pre:border-slate-800 prose-pre:rounded-xl",
+                            "prose-blockquote:border-l-primary-500 prose-blockquote:bg-slate-50 dark:prose-blockquote:bg-slate-900/50 prose-blockquote:py-2 prose-blockquote:px-4 prose-blockquote:rounded-r-lg prose-blockquote:not-italic",
+                            // Drop-cap on the opening paragraph
+                            "[&>p:first-of-type]:first-letter:float-left [&>p:first-of-type]:first-letter:mr-3 [&>p:first-of-type]:first-letter:mt-1 [&>p:first-of-type]:first-letter:font-display [&>p:first-of-type]:first-letter:text-6xl [&>p:first-of-type]:first-letter:font-bold [&>p:first-of-type]:first-letter:leading-[0.8] [&>p:first-of-type]:first-letter:text-primary-600 dark:[&>p:first-of-type]:first-letter:text-primary-400",
+                        ]}
+                    >
+                        <Content />
+                    </div>
+
+                    <!-- Medium Syndication Link -->
+                    {
+                        post.data.mediumUrl && (
+                            <div class="mt-12 pt-8 border-t border-slate-200 dark:border-slate-800">
+                                <a
+                                    href={post.data.mediumUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800 rounded-lg hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
+                                >
+                                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M13.54 12a6.8 6.8 0 01-6.77 6.82A6.8 6.8 0 010 12a6.8 6.8 0 016.77-6.82A6.8 6.8 0 0113.54 12zm7.42 0c0 3.54-1.51 6.42-3.38 6.42-1.87 0-3.39-2.88-3.39-6.42s1.52-6.42 3.39-6.42 3.38 2.88 3.38 6.42M24 12c0 3.17-.53 5.75-1.19 5.75-.66 0-1.19-2.58-1.19-5.75s.53-5.75 1.19-5.75C23.47 6.25 24 8.83 24 12z" />
+                                    </svg>
+                                    Also available on Medium
+                                </a>
+                            </div>
+                        )
+                    }
+                </div>
+            </div>
+        </article>
+    </article-rail>
 
     <script>
-        document.addEventListener("astro:page-load", () => {
-            const handler = () => {
-                const winScroll =
-                    document.body.scrollTop || document.documentElement.scrollTop;
-                const height =
-                    document.documentElement.scrollHeight -
-                    document.documentElement.clientHeight;
-                const scrolled = (winScroll / height) * 100;
-                const bar = document.getElementById("scroll-progress");
-                if (bar) bar.style.width = scrolled + "%";
+        // Reading rail as a Custom Element: connectedCallback/disconnectedCallback
+        // fire on every View-Transition swap, so listeners/observers never leak
+        // (mirrors FullBleedCarouselLayout / ProjectModal lifecycle pattern).
+        class ArticleRail extends HTMLElement {
+            private observer: IntersectionObserver | null = null;
+            private links = new Map<string, HTMLAnchorElement>();
+            private bars: HTMLElement[] = [];
+            private label: HTMLElement | null = null;
+
+            private onScroll = () => {
+                const el = document.documentElement;
+                const max = el.scrollHeight - el.clientHeight;
+                const pct =
+                    max > 0
+                        ? Math.min(100, Math.max(0, (el.scrollTop / max) * 100))
+                        : 0;
+                for (const bar of this.bars) bar.style.width = pct + "%";
+                if (this.label) this.label.textContent = Math.round(pct) + "%";
             };
-            window.addEventListener("scroll", handler);
-        });
+
+            connectedCallback() {
+                this.bars = Array.from(
+                    this.querySelectorAll<HTMLElement>("[data-progress-bar]")
+                );
+                this.label = this.querySelector<HTMLElement>(
+                    "[data-progress-label]"
+                );
+                this.querySelectorAll<HTMLAnchorElement>(
+                    "[data-rail-link]"
+                ).forEach((a) => {
+                    const slug = a.getAttribute("data-rail-link");
+                    if (slug) this.links.set(slug, a);
+                });
+
+                // Active-section highlight (mirrors Header.astro scroll-spy).
+                const heads = Array.from(
+                    document.querySelectorAll<HTMLElement>(
+                        "[data-article-body] :is(h2, h3)[id]"
+                    )
+                );
+                if (heads.length && this.links.size) {
+                    this.observer = new IntersectionObserver(
+                        (entries) => {
+                            for (const entry of entries) {
+                                if (entry.isIntersecting) {
+                                    this.setActive(entry.target.id);
+                                }
+                            }
+                        },
+                        { rootMargin: "-20% 0px -70% 0px", threshold: 0 }
+                    );
+                    heads.forEach((h) => this.observer!.observe(h));
+                }
+
+                window.addEventListener("scroll", this.onScroll, {
+                    passive: true,
+                });
+                this.onScroll();
+            }
+
+            disconnectedCallback() {
+                window.removeEventListener("scroll", this.onScroll);
+                this.observer?.disconnect();
+                this.observer = null;
+                this.links.clear();
+            }
+
+            private setActive(id: string) {
+                this.links.forEach((a, slug) => {
+                    const on = slug === id;
+                    a.classList.toggle("text-slate-900", on);
+                    a.classList.toggle("dark:text-white", on);
+                    a.classList.toggle("!border-primary-500", on);
+                    if (on) a.setAttribute("aria-current", "true");
+                    else a.removeAttribute("aria-current");
+                });
+            }
+        }
+
+        if (!customElements.get("article-rail")) {
+            customElements.define("article-rail", ArticleRail);
+        }
     </script>
 </PageLayout>

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -2,6 +2,11 @@
 import { getCollection } from "astro:content";
 import PageLayout from "@/layouts/PageLayout.astro";
 
+// Editorial type tokens — keep the index consistent with the article page.
+import "@fontsource-variable/space-grotesk";
+import "@fontsource/space-mono/latin-400.css";
+import "@fontsource/space-mono/latin-700.css";
+
 export const prerender = true;
 
 export function getStaticPaths() {
@@ -49,7 +54,7 @@ const sortedPosts = posts.sort(
             <!-- Header -->
             <div class="mb-16 text-center">
                 <h1
-                    class="text-3xl md:text-5xl font-bold text-slate-900 dark:text-white mb-4"
+                    class="font-display text-3xl md:text-5xl font-bold text-slate-900 dark:text-white mb-4 tracking-tight"
                 >
                     {t.title}
                 </h1>
@@ -73,7 +78,7 @@ const sortedPosts = posts.sort(
                                 href={`/${lang}/blog/${post.slug}`}
                                 class="group block bg-white dark:bg-slate-800 rounded-2xl p-6 sm:p-8 shadow-sm hover:shadow-lg border border-slate-100 dark:border-slate-700 transition-all duration-300 hover:-translate-y-0.5"
                             >
-                                <div class="flex items-center gap-3 mb-3 text-sm text-slate-500 dark:text-slate-400 font-mono">
+                                <div class="flex items-center gap-3 mb-3 text-sm text-slate-500 dark:text-slate-400 font-accent">
                                     <time
                                         datetime={post.data.pubDate.toISOString()}
                                     >
@@ -93,7 +98,7 @@ const sortedPosts = posts.sort(
                                     )}
                                 </div>
 
-                                <h2 class="text-xl sm:text-2xl font-bold text-slate-900 dark:text-white mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                                <h2 class="font-display text-xl sm:text-2xl font-bold text-slate-900 dark:text-white mb-2 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
                                     {post.data.title}
                                 </h2>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,4 +9,23 @@
     html {
         -webkit-tap-highlight-color: transparent;
     }
+
+    /* Respect reduced-motion for the global smooth-scroll (html.scroll-smooth) */
+    @media (prefers-reduced-motion: reduce) {
+        html {
+            scroll-behavior: auto;
+        }
+    }
+}
+
+/* Shiki dual-theme: default output uses the light theme; in dark mode
+   swap to the `--shiki-dark` CSS variables Astro emits. Class strategy. */
+html.dark .astro-code,
+html.dark .astro-code span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+    /* Optional font-style/weight variants Shiki may emit */
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
 }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -11,11 +11,34 @@ export default {
         primary: {
           50: '#f0f9ff',
           100: '#e0f2fe',
+          200: '#bae6fd',
+          300: '#7dd3fc',
+          400: '#38bdf8',
           500: '#0ea5e9',
           600: '#0284c7',
           700: '#0369a1',
+          800: '#075985',
+          900: '#0c4a6e',
         }
-      }
+      },
+      fontFamily: {
+        // Body: default sans enriched with system CJK — no webfont download,
+        // just better Traditional Chinese rendering everywhere (zh-tw).
+        sans: [
+          'ui-sans-serif', 'system-ui', '-apple-system', '"Segoe UI"', 'Roboto',
+          '"Noto Sans TC"', '"PingFang TC"', '"Microsoft JhengHei"', 'sans-serif',
+        ],
+        // Display: characterful headings (Latin webfont, loaded on blog pages).
+        display: [
+          '"Space Grotesk Variable"', '"Space Grotesk"',
+          'ui-sans-serif', 'system-ui', 'sans-serif',
+        ],
+        // Accent: structural mono — section numbers, eyebrows, meta.
+        // Separate from the default `mono` so the site header logo is untouched.
+        accent: [
+          '"Space Mono"', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace',
+        ],
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
Closes #19.

Redesigns the blog article page from a generic centred `prose-slate` column into a distinctive **"Technical Director's editorial"** layout — monospace as the structural accent over the existing `primary` + `purple` gradient — with no runtime framework and View-Transition-safe listeners.

## What changed

**Type & tokens** (`tailwind.config.mjs`, `@fontsource`)
- New `display` (Space Grotesk) + `accent` (Space Mono) font tokens — self-hosted, Latin-only, loaded on blog pages. Global `mono` left untouched (header logo unaffected).
- `sans` enriched with system CJK fallback — **no CJK webfont download**.
- Filled the missing `primary` 200/300/400/800/900 shades (fixes the dead `primary-400` dark-link reference).

**Article page** (`[...slug].astro`)
- Asymmetric two-column editorial grid; mono eyebrow, left-aligned display H1, mono meta line (date / author / **reading time**, bilingual, computed inline for Latin + CJK), drop-cap, lang-aware measure (70ch / 34em).
- **Signature section rail** as an `<article-rail>` Custom Element: auto-generated server-side from `render().headings`, active-section highlight (IntersectionObserver), integrated reading progress (rail fill + % desktop / thin top bar mobile). Real `<a>` anchors, sticky, collapses on mobile.
- **Leak fix folded in:** the old `astro:page-load` scroll listener that accumulated across View Transitions is replaced by the `connectedCallback`/`disconnectedCallback` lifecycle.

**Markdown** (`astro.config.mjs`, `global.css`)
- Dual-theme Shiki (`github-light`/`github-dark`) with a `.dark` CSS-var switch; removed the conflicting `prose-pre` background. `prefers-reduced-motion` scroll guard.

**Key finding:** Astro already auto-adds heading `id`s (verified, incl. CJK slugs) — so `rehype-slug` was **not** needed. Only new deps are the two `@fontsource` build packages; **zero runtime frameworks**.

## Verification

- ✅ `npm run build` green; `npx astro check` 0 errors.
- ✅ Rendered en + zh-tw; rail link count == heading count (10/10 zh, 3/3 en); CJK slugs intact.
- ✅ Shiki dual theme confirmed in built HTML (45 `--shiki-dark` vars in the code-bearing post).
- ✅ Visually verified (Edge/puppeteer) desktop light+dark, mobile, active-rail highlight, drop-cap, progress gradient.
- ✅ **No listener leak** — empirical: scroll-listener count toggles 1 (index) ↔ 2 (post) across 3 View-Transition round-trips, never growing; `<article-rail>` count toggles 0 ↔ 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)