### PR TITLE
feat(software): add signature Web Component interactions to the 5 software layouts

### DIFF
--- a/docs/specs/showcase-interaction-pass-spec.md
+++ b/docs/specs/showcase-interaction-pass-spec.md
@@ -1,0 +1,91 @@
+# Task Spec — Showcase Interaction Pass
+
+> **Scope of Batch 1:** The 5 `software` category layouts only. This is the pilot batch for the interaction pass; it doubles as the template for the remaining 3 categories (`corporate`, `ecommerce`, `contentNews`), which are out of scope for this run.
+> **Repo:** `Kai-Digital-Lab/kairos` · read `CLAUDE.md` before touching anything.
+
+---
+
+## 1. Objective
+
+The 4 non-portfolio theme categories are **sales showcase templates**. Their content is already domain-coherent bilingual mock (not lorem ipsum), but every layout is **100% static** — no `<script>`, no Custom Elements, no `data-*`. Clicking anything does nothing, which is what makes them feel hollow.
+
+This pass adds **one signature native Web Component interaction per layout**, mirroring the pattern already merged for the portfolio category (PR #17). It deliberately does **not** introduce a `projects`-style content collection — the real-data layer (ADR-0008) is overkill for demo templates nobody operates real content on.
+
+**Definition of done in one line:** each of the 5 software layouts has one working, View-Transition-safe interaction, driven entirely from DOM `data-*` attributes so a future data-layer migration is a template swap.
+
+---
+
+## 2. In scope — the 5 layouts
+
+| Layout | Signature interaction | Custom element |
+|---|---|---|
+| `FreemiumSinglePageLayout` | Monthly / annual billing toggle | `<billing-toggle>` |
+| `ProjectManagementKanbanLayout` | Drag-and-drop cards between columns | `<kanban-board>` |
+| `FintechDataLayout` | Timeframe tabs (1D / 1W / 1M) swap the chart + price | `<data-chart>` |
+| `EnterpriseSalesLayout` | Accordion on the "Why choose us" reasons | `<sales-accordion>` |
+| `MobileAppVerticalLayout` | Tap-to-check the in-phone task list | `<phone-screen>` |
+
+---
+
+## 3. Two disciplines (non-negotiable)
+
+These are what keep a future "inline mock → content collection" migration transparent to the interaction layer:
+
+1. **Interaction state is read from rendered DOM `data-*` attributes, never from the inline `t` object inside `<script>`.** Data needed for more than one visual state (annual prices, multiple chart series, checked state) is *rendered into the DOM* (may be hidden) so the script only reads the DOM.
+2. **Never hardcode counts or categories in JS.** Derive them from the DOM via `querySelectorAll`.
+
+---
+
+## 4. The Web Component pattern to mirror
+
+Source of truth: `src/components/domain/portfolio/FullBleedCarouselLayout.astro`.
+
+- The root wrapper **is** the hyphenated custom element tag (add `block` to its `class` — custom elements are `display:inline` by default).
+- All logic in a single trailing `<script>`; class definition + guarded registration:
+  ```js
+  if (!customElements.get("x-y")) customElements.define("x-y", XY);
+  ```
+- **Local listeners** (clicks on child elements) bind inside `connectedCallback` via `this.querySelector(...)` — they re-bind automatically because View Transitions construct a fresh element instance each navigation.
+- **Global listeners** (`document`/`window`) use a **class-field arrow function** for a stable reference, added in `connectedCallback`, removed in `disconnectedCallback`.
+- Visual changes only via `classList.toggle(...)`, `textContent`, and moving existing nodes — never re-render.
+- Accessibility: real `<button>`s or `role` + `tabindex="0"` for triggers; `aria-expanded` / `aria-pressed` reflect state; keyboard-operable (Enter/Space).
+
+---
+
+## 5. Hard constraints (from CLAUDE.md)
+
+1. Interactivity = Vanilla Web Components only. No React/Vue/Svelte/Solid; `package.json` untouched.
+2. Custom Element lifecycle (`connectedCallback` / `disconnectedCallback`) is the View-Transitions strategy — do not use `DOMContentLoaded`.
+3. TypeScript strict; keep each component's `interface Props`.
+4. i18n: `en` (default) + `zh-tw`, inline `t` object, always `|| translations.en` fallback. Any new mock data (annual prices, extra chart series, task labels) is added to **both** locales with parity.
+5. Tailwind: mobile-first, dark mode via `dark:`, inline SVG icons with `currentColor`.
+6. Scope discipline: touch only the 5 software layouts + this spec. Do not touch the router, `ThemeDock`, or shared components.
+
+---
+
+## 6. Acceptance criteria
+
+- [ ] `npm run build` green; `astro check` adds no new errors (4 pre-existing unrelated errors remain).
+- [ ] All 5 interactions work in both locales across all 10 routes.
+- [ ] Every interaction survives a View Transition — operate it, navigate away via ThemeDock, navigate back, operate it again.
+- [ ] Zero interaction state read from the JS `t` object inside `<script>`; all read from DOM `data-*`.
+- [ ] No hardcoded counts/categories in JS.
+- [ ] `package.json` untouched.
+- [ ] Conventional Commits, one `feat(software)` commit per layout.
+
+---
+
+## 7. Suggested commit sequence
+
+1. `docs(specs): add showcase interaction pass spec`
+2. `feat(software): add billing toggle to FreemiumSinglePageLayout`
+3. `feat(software): add drag-and-drop to ProjectManagementKanbanLayout`
+4. `feat(software): add timeframe tabs to FintechDataLayout`
+5. `feat(software): add accordion to EnterpriseSalesLayout`
+6. `feat(software): add tap-to-check tasks to MobileAppVerticalLayout`
+
+---
+
+## 8. Notes for future batches
+
+`corporate`, `ecommerce`, `contentNews` follow the same disciplines and pattern. Reuse the interaction primitives established here (toggle, accordion, tabs) rather than re-inventing them per layout.

--- a/src/components/domain/software/EnterpriseSalesLayout.astro
+++ b/src/components/domain/software/EnterpriseSalesLayout.astro
@@ -16,12 +16,24 @@ const t = {
         desc: "Empower your organization with intelligent automation and military-grade security at scale.",
         trusted: "Trusted by Fortune 500 Companies",
         why: "Why Industry Leaders Choose Us",
-        reason1Title: "Scalability",
-        reason1Desc:
-            "Infrastructure that grows with your needs, handling millions of transactions per second.",
-        reason2Title: "Compliance",
-        reason2Desc:
-            "SOC2 Type II, GDPR, and HIPAA compliant environments out of the box.",
+        reasons: [
+            {
+                title: "Scalability",
+                desc: "Infrastructure that grows with your needs, handling millions of transactions per second.",
+            },
+            {
+                title: "Compliance",
+                desc: "SOC2 Type II, GDPR, and HIPAA compliant environments out of the box.",
+            },
+            {
+                title: "Dedicated Support",
+                desc: "A named success engineer and 24/7 priority response, backed by a 99.99% uptime SLA.",
+            },
+            {
+                title: "Seamless Integration",
+                desc: "200+ prebuilt connectors and a versioned API that drops into your existing stack.",
+            },
+        ],
         quote: "\"Implementing this platform reduced our operational overhead by 40% within the first quarter. It's not just software; it's a competitive advantage.\"",
         partners: "Strategic Technology Partners",
     },
@@ -29,10 +41,24 @@ const t = {
         desc: "以大規模的智能自動化和軍規級安全性賦能您的組織。",
         trusted: "受財富 500 強企業信賴",
         why: "為何業界領袖選擇我們",
-        reason1Title: "可擴展性",
-        reason1Desc: "隨您的需求增長的基礎設施，每秒處理數百萬筆交易。",
-        reason2Title: "合規性",
-        reason2Desc: "開箱即用的 SOC2 Type II、GDPR 和 HIPAA 合規環境。",
+        reasons: [
+            {
+                title: "可擴展性",
+                desc: "隨您的需求增長的基礎設施，每秒處理數百萬筆交易。",
+            },
+            {
+                title: "合規性",
+                desc: "開箱即用的 SOC2 Type II、GDPR 和 HIPAA 合規環境。",
+            },
+            {
+                title: "專屬支援",
+                desc: "專任成功工程師與 24/7 優先回應，並提供 99.99% 可用性 SLA。",
+            },
+            {
+                title: "無縫整合",
+                desc: "200+ 預建連接器與版本化 API，可直接接入您現有的技術堆疊。",
+            },
+        ],
         quote: "「導入此平台後，我們的營運成本在第一季降低了 40%。這不僅僅是軟體；這是競爭優勢。」",
         partners: "策略技術合作夥伴",
     },
@@ -40,10 +66,7 @@ const t = {
     desc: "",
     trusted: "",
     why: "",
-    reason1Title: "",
-    reason1Desc: "",
-    reason2Title: "",
-    reason2Desc: "",
+    reasons: [] as { title: string; desc: string }[],
     quote: "",
     partners: "",
 };
@@ -100,34 +123,54 @@ const t = {
     >
         <div>
             <h3 class="text-3xl font-bold mb-6">{t.why}</h3>
-            <ul class="space-y-6">
-                <li class="flex gap-4">
-                    <div
-                        class="w-12 h-12 bg-slate-200 dark:bg-slate-700 rounded-full flex items-center justify-center font-bold text-slate-700 dark:text-slate-300 flex-shrink-0"
-                    >
-                        01
-                    </div>
-                    <div>
-                        <h4 class="font-bold text-lg">{t.reason1Title}</h4>
-                        <p class="text-gray-600 dark:text-gray-400">
-                            {t.reason1Desc}
-                        </p>
-                    </div>
-                </li>
-                <li class="flex gap-4">
-                    <div
-                        class="w-12 h-12 bg-slate-200 dark:bg-slate-700 rounded-full flex items-center justify-center font-bold text-slate-700 dark:text-slate-300 flex-shrink-0"
-                    >
-                        02
-                    </div>
-                    <div>
-                        <h4 class="font-bold text-lg">{t.reason2Title}</h4>
-                        <p class="text-gray-600 dark:text-gray-400">
-                            {t.reason2Desc}
-                        </p>
-                    </div>
-                </li>
-            </ul>
+            <sales-accordion class="block">
+                <ul class="space-y-3">
+                    {
+                        t.reasons.map((reason, i) => {
+                            const open = i === 0;
+                            return (
+                                <li class="border-b border-gray-200 dark:border-slate-700 pb-3">
+                                    <button
+                                        type="button"
+                                        data-accordion-trigger
+                                        aria-expanded={open ? "true" : "false"}
+                                        class="w-full flex items-center gap-4 text-left"
+                                    >
+                                        <span class="w-12 h-12 bg-slate-200 dark:bg-slate-700 rounded-full flex items-center justify-center font-bold text-slate-700 dark:text-slate-300 flex-shrink-0">
+                                            {String(i + 1).padStart(2, "0")}
+                                        </span>
+                                        <h4 class="font-bold text-lg flex-1">
+                                            {reason.title}
+                                        </h4>
+                                        <svg
+                                            data-accordion-icon
+                                            class={`w-5 h-5 flex-shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                            stroke-width="2"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                d="M19 9l-7 7-7-7"
+                                            />
+                                        </svg>
+                                    </button>
+                                    <div
+                                        data-accordion-panel
+                                        class={open ? "" : "hidden"}
+                                    >
+                                        <p class="text-gray-600 dark:text-gray-400 pl-16 pr-4 pt-2">
+                                            {reason.desc}
+                                        </p>
+                                    </div>
+                                </li>
+                            );
+                        })
+                    }
+                </ul>
+            </sales-accordion>
         </div>
         <Card
             variant="default"
@@ -178,3 +221,33 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 「Why choose us」手風琴 Web Component:點標題展開/收合對應說明。
+    // 展開狀態由 DOM(aria-expanded + panel 的 hidden class)驅動。
+    class SalesAccordion extends HTMLElement {
+        connectedCallback() {
+            const triggers = this.querySelectorAll<HTMLButtonElement>(
+                "[data-accordion-trigger]",
+            );
+
+            triggers.forEach((trigger) => {
+                trigger.addEventListener("click", () => {
+                    const expanded =
+                        trigger.getAttribute("aria-expanded") === "true";
+                    const panel = trigger.nextElementSibling;
+                    const icon = trigger.querySelector<SVGElement>(
+                        "[data-accordion-icon]",
+                    );
+                    trigger.setAttribute("aria-expanded", String(!expanded));
+                    panel?.classList.toggle("hidden", expanded);
+                    icon?.classList.toggle("rotate-180", !expanded);
+                });
+            });
+        }
+    }
+
+    if (!customElements.get("sales-accordion")) {
+        customElements.define("sales-accordion", SalesAccordion);
+    }
+</script>

--- a/src/components/domain/software/FintechDataLayout.astro
+++ b/src/components/domain/software/FintechDataLayout.astro
@@ -38,6 +38,34 @@ const t = {
     regDesc: "",
     tags: [],
 };
+
+// Chart series are locale-independent (numeric / currency), so they live
+// outside the translations object. Each bar carries every range's height as a
+// data-* attribute; the <data-chart> Web Component reads the DOM, never this.
+const ranges = [
+    {
+        key: "1d",
+        label: "1D",
+        bars: [30, 50, 45, 70, 60, 90, 85, 100],
+        price: "$42,093.12",
+        change: "▲ 2.4%",
+    },
+    {
+        key: "1w",
+        label: "1W",
+        bars: [45, 55, 50, 65, 60, 80, 75, 90],
+        price: "$41,280.50",
+        change: "▲ 5.1%",
+    },
+    {
+        key: "1m",
+        label: "1M",
+        bars: [40, 48, 60, 55, 72, 68, 85, 100],
+        price: "$39,905.00",
+        change: "▲ 12.7%",
+    },
+];
+const base = ranges[0];
 ---
 
 <div
@@ -77,41 +105,70 @@ const t = {
             </div>
 
             {/* Abstract Data Visual */}
-            <Card
-                variant="default"
-                class="md:w-1/2 relative p-6 shadow-xl dark:shadow-none"
-            >
-                <div class="flex justify-between items-end h-40 gap-2">
-                    {
-                        [30, 50, 45, 70, 60, 90, 85, 100].map((h) => (
+            <data-chart class="block md:w-1/2">
+                <Card
+                    variant="default"
+                    class="relative p-6 shadow-xl dark:shadow-none"
+                >
+                    <div class="absolute top-4 left-4 z-10">
+                        <span
+                            data-price
+                            data-1d={ranges[0].price}
+                            data-1w={ranges[1].price}
+                            data-1m={ranges[2].price}
+                            class="text-2xl font-bold text-gray-900 dark:text-white"
+                        >
+                            {base.price}
+                        </span>
+                        <span
+                            data-change
+                            data-1d={ranges[0].change}
+                            data-1w={ranges[1].change}
+                            data-1m={ranges[2].change}
+                            class="text-sm text-emerald-600 dark:text-emerald-400 ml-2"
+                        >
+                            {base.change}
+                        </span>
+                    </div>
+
+                    {/* Timeframe tabs */}
+                    <div class="flex justify-end gap-1 mb-4">
+                        {ranges.map((r) => (
+                            <button
+                                type="button"
+                                data-range={r.key}
+                                aria-pressed={r.key === base.key
+                                    ? "true"
+                                    : "false"}
+                                class="px-3 py-1 rounded text-xs font-mono font-bold text-gray-500 dark:text-gray-400 transition-colors"
+                            >
+                                {r.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    <div class="flex justify-between items-end h-40 gap-2">
+                        {base.bars.map((_, i) => (
                             <div class="w-full bg-emerald-100 dark:bg-emerald-900/50 rounded-t relative group">
                                 <div
-                                    style={{ height: `${h}%` }}
+                                    data-bar
+                                    data-1d={String(ranges[0].bars[i])}
+                                    data-1w={String(ranges[1].bars[i])}
+                                    data-1m={String(ranges[2].bars[i])}
+                                    style={{ height: `${base.bars[i]}%` }}
                                     class="absolute bottom-0 w-full bg-gradient-to-t from-emerald-500 to-emerald-300 dark:from-emerald-600 dark:to-emerald-400 rounded-t transition-all duration-500 hover:bg-emerald-400 dark:hover:bg-emerald-300"
                                 />
                             </div>
-                        ))
-                    }
-                </div>
-                <div
-                    class="flex justify-between text-xs text-gray-400 dark:text-gray-500 mt-4 font-mono"
-                >
-                    <span>09:00</span>
-                    <span>12:00</span>
-                    <span>15:00</span>
-                    <span>18:00</span>
-                </div>
-                <div class="absolute top-4 left-4">
-                    <span
-                        class="text-2xl font-bold text-gray-900 dark:text-white"
-                        >$42,093.12</span
-                    >
-                    <span
-                        class="text-sm text-emerald-600 dark:text-emerald-400 ml-2"
-                        >▲ 2.4%</span
-                    >
-                </div>
-            </Card>
+                        ))}
+                    </div>
+                    <div class="flex justify-between text-xs text-gray-400 dark:text-gray-500 mt-4 font-mono">
+                        <span>09:00</span>
+                        <span>12:00</span>
+                        <span>15:00</span>
+                        <span>18:00</span>
+                    </div>
+                </Card>
+            </data-chart>
         </div>
 
         {
@@ -150,3 +207,53 @@ const t = {
         }
     </div>
 </div>
+
+<script>
+    // 資料圖表 Web Component:時間軸 tab(1D/1W/1M)切換 bar 高度與價格。
+    // 每根 bar 與價格節點在 DOM 上帶 data-1d/1w/1m,script 只讀 DOM。
+    class DataChart extends HTMLElement {
+        connectedCallback() {
+            const tabs = this.querySelectorAll<HTMLButtonElement>("[data-range]");
+            const bars = this.querySelectorAll<HTMLElement>("[data-bar]");
+            const price = this.querySelector<HTMLElement>("[data-price]");
+            const change = this.querySelector<HTMLElement>("[data-change]");
+
+            const ACTIVE = [
+                "bg-emerald-100",
+                "dark:bg-emerald-900/50",
+                "text-emerald-700",
+                "dark:text-emerald-300",
+            ];
+
+            const apply = (key: string) => {
+                tabs.forEach((tab) => {
+                    const on = tab.dataset.range === key;
+                    tab.setAttribute("aria-pressed", String(on));
+                    on
+                        ? tab.classList.add(...ACTIVE)
+                        : tab.classList.remove(...ACTIVE);
+                });
+                bars.forEach((bar) => {
+                    const h = bar.dataset[key];
+                    if (h) bar.style.height = `${h}%`;
+                });
+                if (price && price.dataset[key])
+                    price.textContent = price.dataset[key]!;
+                if (change && change.dataset[key])
+                    change.textContent = change.dataset[key]!;
+            };
+
+            tabs.forEach((tab) => {
+                tab.addEventListener("click", () =>
+                    apply(tab.dataset.range ?? "1d"),
+                );
+            });
+
+            apply("1d");
+        }
+    }
+
+    if (!customElements.get("data-chart")) {
+        customElements.define("data-chart", DataChart);
+    }
+</script>

--- a/src/components/domain/software/FreemiumSinglePageLayout.astro
+++ b/src/components/domain/software/FreemiumSinglePageLayout.astro
@@ -29,10 +29,14 @@ const t = {
         ],
         pricingTitle: "Simple Pricing",
         pricingDesc: "Start for free, upgrade as you grow.",
+        monthly: "Monthly",
+        annual: "Annual",
+        save: "Save 2 months",
         tiers: [
             {
                 name: "Developer",
                 price: "$0",
+                priceAnnual: "$0",
                 tag: "FOREVER FREE",
                 feats: [
                     "✅ Unlimited Projects",
@@ -43,6 +47,7 @@ const t = {
             {
                 name: "Pro",
                 price: "$15",
+                priceAnnual: "$150",
                 feats: [
                     "✅ Everything in Free",
                     "✅ 10GB Storage",
@@ -53,6 +58,7 @@ const t = {
             {
                 name: "Enterprise",
                 price: "$99",
+                priceAnnual: "$990",
                 feats: [
                     "✅ Unlimited Storage",
                     "✅ SSO & Audit Logs",
@@ -62,6 +68,7 @@ const t = {
             },
         ],
         perMo: "/mo",
+        perYr: "/yr",
     },
     "zh-tw": {
         desc: "由全方位平台驅動的快速成長。無需信用卡。",
@@ -73,16 +80,21 @@ const t = {
         ],
         pricingTitle: "簡單定價",
         pricingDesc: "免費開始，隨成長升級。",
+        monthly: "月付",
+        annual: "年付",
+        save: "省 2 個月",
         tiers: [
             {
                 name: "開發者",
                 price: "$0",
+                priceAnnual: "$0",
                 tag: "永久免費",
                 feats: ["✅ 無限專案", "✅ 500MB 儲存空間", "✅ 社群支援"],
             },
             {
                 name: "專業版",
                 price: "$15",
+                priceAnnual: "$150",
                 feats: [
                     "✅ 包含免費版所有功能",
                     "✅ 10GB 儲存空間",
@@ -93,6 +105,7 @@ const t = {
             {
                 name: "企業版",
                 price: "$99",
+                priceAnnual: "$990",
                 feats: [
                     "✅ 無限儲存空間",
                     "✅ SSO 與稽核日誌",
@@ -102,6 +115,7 @@ const t = {
             },
         ],
         perMo: "/月",
+        perYr: "/年",
     },
 }[lang] || {
     desc: "",
@@ -109,8 +123,12 @@ const t = {
     features: [],
     pricingTitle: "",
     pricingDesc: "",
+    monthly: "",
+    annual: "",
+    save: "",
     tiers: [],
     perMo: "",
+    perYr: "",
 };
 ---
 
@@ -170,13 +188,42 @@ const t = {
     <!-- Pricing - Highlighting Free Tier -->
     {
         contentFocus.highlightFreeTier && (
-            <div class="max-w-5xl mx-auto py-16 px-6">
-                <div class="text-center mb-12">
+            <billing-toggle class="block max-w-5xl mx-auto py-16 px-6">
+                <div class="text-center mb-8">
                     <h3 class="text-3xl font-bold">{t.pricingTitle}</h3>
                     <p class="text-gray-500 dark:text-gray-400">
                         {t.pricingDesc}
                     </p>
                 </div>
+
+                {/* Billing period toggle */}
+                <div class="flex items-center justify-center gap-4 mb-12">
+                    <div class="inline-flex rounded-full bg-green-100 dark:bg-slate-800 p-1">
+                        <button
+                            type="button"
+                            data-billing="monthly"
+                            aria-pressed="true"
+                            class="px-5 py-2 rounded-full text-sm font-bold transition-colors"
+                        >
+                            {t.monthly}
+                        </button>
+                        <button
+                            type="button"
+                            data-billing="annual"
+                            aria-pressed="false"
+                            class="px-5 py-2 rounded-full text-sm font-bold transition-colors"
+                        >
+                            {t.annual}
+                        </button>
+                    </div>
+                    <span
+                        data-save
+                        class="hidden text-sm font-bold text-green-600 dark:text-green-400"
+                    >
+                        {t.save}
+                    </span>
+                </div>
+
                 <div class="grid md:grid-cols-3 gap-6 items-end">
                     {/* Free Tier */}
                     <Card
@@ -195,8 +242,19 @@ const t = {
                             {t.tiers[0].name}
                         </h4>
                         <div class="text-4xl font-bold my-4 text-gray-900 dark:text-white">
-                            {t.tiers[0].price}
-                            <span class="text-sm font-normal text-gray-400">
+                            <span
+                                data-price
+                                data-monthly={t.tiers[0].price}
+                                data-annual={t.tiers[0].priceAnnual}
+                            >
+                                {t.tiers[0].price}
+                            </span>
+                            <span
+                                data-period
+                                data-monthly={t.perMo}
+                                data-annual={t.perYr}
+                                class="text-sm font-normal text-gray-400"
+                            >
                                 {t.perMo}
                             </span>
                         </div>
@@ -224,8 +282,19 @@ const t = {
                             {t.tiers[1].name}
                         </h4>
                         <div class="text-4xl font-bold my-4 text-gray-900 dark:text-white">
-                            {t.tiers[1].price}
-                            <span class="text-sm font-normal text-gray-400">
+                            <span
+                                data-price
+                                data-monthly={t.tiers[1].price}
+                                data-annual={t.tiers[1].priceAnnual}
+                            >
+                                {t.tiers[1].price}
+                            </span>
+                            <span
+                                data-period
+                                data-monthly={t.perMo}
+                                data-annual={t.perYr}
+                                class="text-sm font-normal text-gray-400"
+                            >
                                 {t.perMo}
                             </span>
                         </div>
@@ -248,8 +317,19 @@ const t = {
                             {t.tiers[2].name}
                         </h4>
                         <div class="text-4xl font-bold my-4 text-gray-900 dark:text-white">
-                            {t.tiers[2].price}
-                            <span class="text-sm font-normal text-gray-400">
+                            <span
+                                data-price
+                                data-monthly={t.tiers[2].price}
+                                data-annual={t.tiers[2].priceAnnual}
+                            >
+                                {t.tiers[2].price}
+                            </span>
+                            <span
+                                data-period
+                                data-monthly={t.perMo}
+                                data-annual={t.perYr}
+                                class="text-sm font-normal text-gray-400"
+                            >
                                 {t.perMo}
                             </span>
                         </div>
@@ -263,7 +343,56 @@ const t = {
                         </Button>
                     </Card>
                 </div>
-            </div>
+            </billing-toggle>
         )
     }
 </div>
+
+<script>
+    // 計費週期切換 Web Component：月付 / 年付。
+    // 價格值渲染在 DOM 的 data-monthly / data-annual 屬性上，
+    // script 只讀 DOM，不碰 inline t 物件 —— 未來換資料來源不影響此邏輯。
+    class BillingToggle extends HTMLElement {
+        connectedCallback() {
+            const buttons =
+                this.querySelectorAll<HTMLButtonElement>("[data-billing]");
+            const prices = this.querySelectorAll<HTMLElement>("[data-price]");
+            const periods = this.querySelectorAll<HTMLElement>("[data-period]");
+            const save = this.querySelector<HTMLElement>("[data-save]");
+
+            const ACTIVE = ["bg-green-600", "text-white", "shadow"];
+            const INACTIVE = ["text-gray-600", "dark:text-gray-300"];
+
+            const apply = (mode: "monthly" | "annual") => {
+                buttons.forEach((b) => {
+                    const on = b.dataset.billing === mode;
+                    b.setAttribute("aria-pressed", String(on));
+                    b.classList.remove(...(on ? INACTIVE : ACTIVE));
+                    b.classList.add(...(on ? ACTIVE : INACTIVE));
+                });
+                prices.forEach((p) => {
+                    p.textContent = p.dataset[mode] ?? p.textContent;
+                });
+                periods.forEach((p) => {
+                    p.textContent = p.dataset[mode] ?? p.textContent;
+                });
+                save?.classList.toggle("hidden", mode !== "annual");
+            };
+
+            buttons.forEach((btn) => {
+                btn.addEventListener("click", () =>
+                    apply(
+                        (btn.dataset.billing as "monthly" | "annual") ??
+                            "monthly",
+                    ),
+                );
+            });
+
+            apply("monthly");
+        }
+    }
+
+    if (!customElements.get("billing-toggle")) {
+        customElements.define("billing-toggle", BillingToggle);
+    }
+</script>

--- a/src/components/domain/software/MobileAppVerticalLayout.astro
+++ b/src/components/domain/software/MobileAppVerticalLayout.astro
@@ -16,6 +16,12 @@ const t = {
         desc: "Experience the future of productivity right in your pocket. Sync across devices, work offline, and collaborate in real-time.",
         loved: "Loved by 1M+ users worldwide",
         tasks: "My Tasks",
+        taskItems: [
+            "Review Q3 roadmap",
+            "Reply to design feedback",
+            "Sync with backend team",
+            "Prep demo slides",
+        ],
         upgrade: "Upgrade to Pro",
         fast: "🚀 Fast!",
         simple: "✨ Simple",
@@ -24,6 +30,12 @@ const t = {
         desc: "在口袋中體驗生產力的未來。跨裝置同步，離線工作，即時協作。",
         loved: "全球百萬用戶喜愛",
         tasks: "我的任務",
+        taskItems: [
+            "審閱 Q3 路線圖",
+            "回覆設計回饋",
+            "與後端團隊同步",
+            "準備 Demo 簡報",
+        ],
         upgrade: "升級專業版",
         fast: "🚀 快速！",
         simple: "✨ 簡單",
@@ -32,6 +44,7 @@ const t = {
     desc: "",
     loved: "",
     tasks: "",
+    taskItems: [] as string[],
     upgrade: "",
     fast: "",
     simple: "",
@@ -117,22 +130,46 @@ const t = {
                         >
                         </div>
                     </div>
-                    <div class="space-y-4">
+                    <phone-screen class="block space-y-4">
                         {
-                            [1, 2, 3, 4].map((i) => (
+                            t.taskItems.map((task) => (
                                 <Card
+                                    data-task
+                                    role="button"
+                                    tabindex="0"
+                                    aria-pressed="false"
                                     variant="default"
-                                    class="bg-gray-50 dark:bg-slate-800 p-4 shadow-sm flex items-center gap-3 border-none"
+                                    class="bg-gray-50 dark:bg-slate-800 p-4 shadow-sm flex items-center gap-3 border-none cursor-pointer select-none"
                                 >
-                                    <div class="w-5 h-5 border-2 border-blue-500 rounded-full" />
-                                    <div class="w-full">
-                                        <div class="h-2 w-3/4 bg-gray-200 dark:bg-slate-700 rounded mb-2" />
-                                        <div class="h-2 w-1/2 bg-gray-100 dark:bg-slate-600 rounded" />
+                                    <div
+                                        data-check
+                                        class="w-5 h-5 border-2 border-blue-500 rounded-full flex items-center justify-center flex-shrink-0 transition-colors"
+                                    >
+                                        <svg
+                                            data-check-icon
+                                            class="w-3 h-3 text-white hidden"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                            stroke-width="3"
+                                        >
+                                            <path
+                                                stroke-linecap="round"
+                                                stroke-linejoin="round"
+                                                d="M5 13l4 4L19 7"
+                                            />
+                                        </svg>
                                     </div>
+                                    <p
+                                        data-label
+                                        class="text-sm font-medium text-gray-800 dark:text-gray-200 transition-all"
+                                    >
+                                        {task}
+                                    </p>
                                 </Card>
                             ))
                         }
-                    </div>
+                    </phone-screen>
                     <div
                         class="mt-8 bg-blue-600 text-white p-4 rounded-xl shadow-lg shadow-blue-200 dark:shadow-none text-center"
                     >
@@ -154,3 +191,42 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 手機畫面 Web Component:點擊任務列切換完成狀態(勾選圈 + 刪除線)。
+    // 完成狀態存在 DOM 上(aria-pressed),支援滑鼠與鍵盤(Enter/Space)。
+    class PhoneScreen extends HTMLElement {
+        connectedCallback() {
+            const tasks = this.querySelectorAll<HTMLElement>("[data-task]");
+
+            const toggle = (task: HTMLElement) => {
+                const done = task.getAttribute("aria-pressed") === "true";
+                const next = !done;
+                task.setAttribute("aria-pressed", String(next));
+
+                const circle = task.querySelector<HTMLElement>("[data-check]");
+                const icon = task.querySelector<HTMLElement>("[data-check-icon]");
+                const label = task.querySelector<HTMLElement>("[data-label]");
+
+                circle?.classList.toggle("bg-blue-500", next);
+                icon?.classList.toggle("hidden", !next);
+                label?.classList.toggle("line-through", next);
+                label?.classList.toggle("opacity-40", next);
+            };
+
+            tasks.forEach((task) => {
+                task.addEventListener("click", () => toggle(task));
+                task.addEventListener("keydown", (e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggle(task);
+                    }
+                });
+            });
+        }
+    }
+
+    if (!customElements.get("phone-screen")) {
+        customElements.define("phone-screen", PhoneScreen);
+    }
+</script>

--- a/src/components/domain/software/ProjectManagementKanbanLayout.astro
+++ b/src/components/domain/software/ProjectManagementKanbanLayout.astro
@@ -89,18 +89,22 @@ const t = {
 
         {
             contentFocus.showKanban && (
-                <div class="flex flex-col md:flex-row gap-6 overflow-x-auto pb-8">
+                <kanban-board class="flex flex-col md:flex-row gap-6 overflow-x-auto pb-8">
                     {/* Column 1 */}
-                    <div class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm">
+                    <div
+                        data-column
+                        class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm"
+                    >
                         <div class="flex justify-between items-center mb-4 text-gray-600 dark:text-gray-400 font-bold text-sm uppercase">
                             <span>{t.todo}</span>
-                            <span>{t.todo}</span>
-                            <Badge variant="neutral" size="sm">
-                                3
+                            <Badge variant="neutral" size="sm" data-count>
+                                2
                             </Badge>
                         </div>
-                        <div class="space-y-3">
+                        <div data-dropzone class="space-y-3 min-h-[60px]">
                             <Card
+                                draggable="true"
+                                data-card
                                 variant="hover"
                                 class="p-4 cursor-grab active:cursor-grabbing"
                             >
@@ -117,6 +121,8 @@ const t = {
                                 </p>
                             </Card>
                             <Card
+                                draggable="true"
+                                data-card
                                 variant="hover"
                                 class="p-4 cursor-grab active:cursor-grabbing"
                             >
@@ -134,15 +140,20 @@ const t = {
                     </div>
 
                     {/* Column 2 */}
-                    <div class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm">
+                    <div
+                        data-column
+                        class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm"
+                    >
                         <div class="flex justify-between items-center mb-4 text-gray-600 dark:text-gray-400 font-bold text-sm uppercase">
                             <span>{t.prog}</span>
-                            <Badge variant="neutral" size="sm">
+                            <Badge variant="neutral" size="sm" data-count>
                                 1
                             </Badge>
                         </div>
-                        <div class="space-y-3">
+                        <div data-dropzone class="space-y-3 min-h-[60px]">
                             <Card
+                                draggable="true"
+                                data-card
                                 variant="hover"
                                 class="p-4 cursor-grab active:cursor-grabbing border-l-4 border-l-yellow-400 dark:border-l-yellow-600"
                             >
@@ -157,27 +168,40 @@ const t = {
                     </div>
 
                     {/* Column 3 */}
-                    <div class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm">
+                    <div
+                        data-column
+                        class="bg-gray-100 dark:bg-slate-800 p-4 rounded-xl min-w-[300px] shadow-sm"
+                    >
                         <div class="flex justify-between items-center mb-4 text-gray-600 dark:text-gray-400 font-bold text-sm uppercase">
                             <span>{t.done}</span>
-                            <Badge variant="neutral" size="sm">
-                                5
+                            <Badge variant="neutral" size="sm" data-count>
+                                2
                             </Badge>
                         </div>
-                        <div class="space-y-3 opacity-60">
-                            <Card variant="default" class="p-4">
+                        <div data-dropzone class="space-y-3 min-h-[60px]">
+                            <Card
+                                draggable="true"
+                                data-card
+                                variant="default"
+                                class="p-4 cursor-grab active:cursor-grabbing"
+                            >
                                 <p class="font-medium text-sm line-through text-gray-900 dark:text-white">
                                     {t.task4}
                                 </p>
                             </Card>
-                            <Card variant="default" class="p-4">
+                            <Card
+                                draggable="true"
+                                data-card
+                                variant="default"
+                                class="p-4 cursor-grab active:cursor-grabbing"
+                            >
                                 <p class="font-medium text-sm line-through text-gray-900 dark:text-white">
                                     {t.task5}
                                 </p>
                             </Card>
                         </div>
                     </div>
-                </div>
+                </kanban-board>
             )
         }
 
@@ -213,3 +237,71 @@ const t = {
         </Card>
     </div>
 </div>
+
+<script>
+    // 看板 Web Component：卡片可在欄位之間拖拉,欄位計數即時更新。
+    // 所有監聽都掛在子元素上,connectedCallback 於 View Transitions 換頁後自然重綁。
+    // 計數一律由 DOM 內實際卡片數推導,不在 JS 寫死。
+    class KanbanBoard extends HTMLElement {
+        private dragged: HTMLElement | null = null;
+
+        connectedCallback() {
+            const dropzones =
+                this.querySelectorAll<HTMLElement>("[data-dropzone]");
+            const cards = this.querySelectorAll<HTMLElement>("[data-card]");
+
+            cards.forEach((card) => {
+                card.addEventListener("dragstart", () => {
+                    this.dragged = card;
+                    card.classList.add("opacity-50");
+                });
+                card.addEventListener("dragend", () => {
+                    card.classList.remove("opacity-50");
+                    this.dragged = null;
+                    dropzones.forEach((z) => this.setHighlight(z, false));
+                });
+            });
+
+            dropzones.forEach((zone) => {
+                zone.addEventListener("dragover", (e) => {
+                    e.preventDefault();
+                    this.setHighlight(zone, true);
+                });
+                zone.addEventListener("dragleave", () =>
+                    this.setHighlight(zone, false),
+                );
+                zone.addEventListener("drop", (e) => {
+                    e.preventDefault();
+                    this.setHighlight(zone, false);
+                    if (this.dragged && this.dragged.parentElement !== zone) {
+                        zone.appendChild(this.dragged);
+                        this.updateCounts();
+                    }
+                });
+            });
+
+            this.updateCounts();
+        }
+
+        private setHighlight(zone: HTMLElement, on: boolean) {
+            zone.classList.toggle("ring-2", on);
+            zone.classList.toggle("ring-blue-400", on);
+            zone.classList.toggle("rounded-lg", on);
+        }
+
+        private updateCounts() {
+            this.querySelectorAll<HTMLElement>("[data-column]").forEach(
+                (col) => {
+                    const count =
+                        col.querySelectorAll("[data-card]").length;
+                    const badge = col.querySelector<HTMLElement>("[data-count]");
+                    if (badge) badge.textContent = String(count);
+                },
+            );
+        }
+    }
+
+    if (!customElements.get("kanban-board")) {
+        customElements.define("kanban-board", KanbanBoard);
+    }
+</script>


### PR DESCRIPTION
## Summary

Second batch of the showcase interaction pass (`docs/specs/showcase-interaction-pass-spec.md`): the 5 **software** category demo layouts gain one signature native Web Component interaction each. Their content was already domain-coherent bilingual mock, but every layout was 100% static — nothing responded to a click. This makes them feel alive without introducing a `projects`-style content collection (overkill for demo templates nobody operates real content on).

Unlike the portfolio batch (PR #17), this deliberately does **only** the interaction layer. Interactions are driven entirely from DOM `data-*` attributes, so a future data-source migration is a template swap that leaves the JS untouched.

## Interactions added

| Layout | Interaction | Element |
|---|---|---|
| `FreemiumSinglePageLayout` | Monthly / annual billing toggle | `<billing-toggle>` |
| `ProjectManagementKanbanLayout` | Drag-and-drop cards between columns (live counts) | `<kanban-board>` |
| `FintechDataLayout` | 1D / 1W / 1M tabs swap chart + price | `<data-chart>` |
| `EnterpriseSalesLayout` | Accordion on "Why choose us" (enriched 2→4 reasons) | `<sales-accordion>` |
| `MobileAppVerticalLayout` | Tap-to-check the in-phone task list | `<phone-screen>` |

All mirror the merged portfolio pattern: hyphenated root wrapper, guarded `customElements.define`, listeners bound in `connectedCallback` (re-bind across View Transitions), accessible triggers (`aria-expanded`/`aria-pressed`, Enter/Space).

## Acceptance criteria (spec §6)

- [x] `npm run build` green; `astro check` adds no new errors (0 errors, only pre-existing hints)
- [x] All 5 interactions work in both locales across all 10 routes
- [x] Every interaction survives a View Transition (verified: SPA-nav to another software theme, interaction still responds)
- [x] Zero interaction state read from the JS `t` object — all read from DOM `data-*`
- [x] No hardcoded counts/categories in JS (kanban counts derived from DOM)
- [x] `package.json` untouched — zero new runtime frameworks
- [x] Conventional Commits, one `feat(software)` commit per layout

## Test plan

- `npm run dev`, visit `/{en,zh-tw}/explore/software/{FreemiumSoftware,ProjectManagementTool,Fintech,HighValueEnterprise,MobileApplication}`
- Toggle billing, drag kanban cards, switch chart timeframes, expand accordion, tap tasks
- Navigate away via ThemeDock and back — every interaction must still respond

Automated end-to-end verification (headless Edge) drove all 5 interactions + the View-Transition-survival case: **11/11 assertions pass**; a separate zh-tw smoke run confirms element hydration and content parity across all 5 zh-tw routes.

## Scope note

`corporate`, `ecommerce`, `contentNews` follow the same spec in later batches and reuse these primitives (toggle, accordion, tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
