### PR TITLE
feat(corporate): add signature Web Component interactions to the 5 corporate layouts

### DIFF
--- a/src/components/domain/corporate/IndustrialModularLayout.astro
+++ b/src/components/domain/corporate/IndustrialModularLayout.astro
@@ -15,11 +15,26 @@ const t = {
         cert: "ISO 9001 Certified • Heavy Industry Solutions",
         flowTitle: "Production Process Flow",
         steps: [
-            "Raw Material",
-            "Fabrication",
-            "Assembly",
-            "QC Check",
-            "Logistics",
+            {
+                label: "Raw Material",
+                desc: "Certified alloy stock is inspected and logged before it enters the line.",
+            },
+            {
+                label: "Fabrication",
+                desc: "CNC machining and robotic welding shape each part to ±0.005mm tolerance.",
+            },
+            {
+                label: "Assembly",
+                desc: "Modules are fitted and torque-verified against the engineering spec.",
+            },
+            {
+                label: "QC Check",
+                desc: "Every unit passes dimensional, load, and non-destructive testing.",
+            },
+            {
+                label: "Logistics",
+                desc: "Finished goods are crated, documented, and scheduled for global shipping.",
+            },
         ],
         tags: ["CNC Machining", "Robotic Welding"],
         capTitle: "Capabilities",
@@ -33,7 +48,28 @@ const t = {
     "zh-tw": {
         cert: "ISO 9001 認證 • 重工業解決方案",
         flowTitle: "生產流程圖",
-        steps: ["原料", "製造", "組裝", "品管", "物流"],
+        steps: [
+            {
+                label: "原料",
+                desc: "認證合金材料進線前先完成檢驗與登錄。",
+            },
+            {
+                label: "製造",
+                desc: "CNC 加工與機器人焊接將每個零件加工至 ±0.005mm 公差。",
+            },
+            {
+                label: "組裝",
+                desc: "模組依工程規格組裝並完成扭力驗證。",
+            },
+            {
+                label: "品管",
+                desc: "每台皆通過尺寸、負載與非破壞性檢測。",
+            },
+            {
+                label: "物流",
+                desc: "成品完成裝箱、文件建檔並排定全球出貨。",
+            },
+        ],
         tags: ["CNC 加工", "機器人焊接"],
         capTitle: "產能規格",
         specs: [
@@ -46,7 +82,7 @@ const t = {
 }[lang] || {
     cert: "",
     flowTitle: "",
-    steps: [],
+    steps: [] as { label: string; desc: string }[],
     tags: [],
     capTitle: "",
     specs: [],
@@ -80,16 +116,22 @@ const t = {
 
         {
             contentFocus.showFlowCharts && (
-                <div class="bg-white dark:bg-slate-900 p-8 shadow-sm mb-8">
+                <process-stepper class="block bg-white dark:bg-slate-900 p-8 shadow-sm mb-8">
                     <h3 class="text-lg font-bold text-gray-500 dark:text-gray-400 uppercase mb-6">
                         {t.flowTitle}
                     </h3>
                     <div class="flex flex-col md:flex-row items-center justify-between gap-4">
-                        {t.steps.map((step: string, idx: number) => (
+                        {t.steps.map((step, idx) => (
                             <>
-                                <div class="bg-gray-100 dark:bg-slate-700 border-2 border-gray-300 dark:border-slate-600 p-4 w-full md:w-32 text-center font-bold text-sm hover:border-orange-500 transition-colors">
-                                    {step}
-                                </div>
+                                <button
+                                    type="button"
+                                    data-step
+                                    data-desc={step.desc}
+                                    aria-pressed={idx === 0 ? "true" : "false"}
+                                    class="bg-gray-100 dark:bg-slate-700 border-2 border-gray-300 dark:border-slate-600 p-4 w-full md:w-32 text-center font-bold text-sm hover:border-orange-500 transition-colors"
+                                >
+                                    {step.label}
+                                </button>
                                 {idx < 4 && (
                                     <div class="hidden md:block text-gray-400 text-xl font-bold">
                                         →
@@ -103,7 +145,15 @@ const t = {
                             </>
                         ))}
                     </div>
-                </div>
+                    <div class="mt-6 border-l-4 border-orange-500 pl-4">
+                        <p
+                            data-step-detail
+                            class="text-gray-600 dark:text-gray-300"
+                        >
+                            {t.steps[0]?.desc}
+                        </p>
+                    </div>
+                </process-stepper>
             )
         }
 
@@ -157,3 +207,42 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 製程步驟器 Web Component:點步驟顯示對應說明。
+    // 說明文字存在每個按鈕的 data-desc 上,script 只讀 DOM。
+    class ProcessStepper extends HTMLElement {
+        connectedCallback() {
+            const steps = this.querySelectorAll<HTMLButtonElement>("[data-step]");
+            const detail = this.querySelector<HTMLElement>("[data-step-detail]");
+
+            const ACTIVE = [
+                "border-orange-500",
+                "bg-orange-50",
+                "dark:bg-orange-900/20",
+            ];
+
+            const select = (btn: HTMLButtonElement) => {
+                steps.forEach((s) => {
+                    const on = s === btn;
+                    s.setAttribute("aria-pressed", String(on));
+                    on
+                        ? s.classList.add(...ACTIVE)
+                        : s.classList.remove(...ACTIVE);
+                });
+                if (detail && btn.dataset.desc)
+                    detail.textContent = btn.dataset.desc;
+            };
+
+            steps.forEach((btn) => {
+                btn.addEventListener("click", () => select(btn));
+            });
+
+            if (steps[0]) select(steps[0]);
+        }
+    }
+
+    if (!customElements.get("process-stepper")) {
+        customElements.define("process-stepper", ProcessStepper);
+    }
+</script>

--- a/src/components/domain/corporate/MedicalClinicLayout.astro
+++ b/src/components/domain/corporate/MedicalClinicLayout.astro
@@ -18,6 +18,11 @@ const t = {
         desc: "Compassionate care powered by advanced medical technology. Your health is our priority.",
         quick: "Quick Appointment",
         noAcc: "No account required.",
+        fName: "Full name",
+        fDate: "Preferred date",
+        fDept: "Select department",
+        fSuccess: "Thanks! We'll confirm your appointment shortly.",
+        fError: "Please complete all fields.",
         meet: "Meet Our Specialists",
         view: "View Profile",
         doctors: [
@@ -31,6 +36,11 @@ const t = {
         desc: "以先進醫療科技提供充滿關懷的照護。您的健康是我們的首要任務。",
         quick: "快速預約",
         noAcc: "無需註冊",
+        fName: "姓名",
+        fDate: "希望日期",
+        fDept: "選擇科別",
+        fSuccess: "感謝您！我們將盡快確認您的預約。",
+        fError: "請填寫所有欄位。",
         meet: "認識我們的專家",
         view: "查看簡介",
         doctors: [
@@ -44,9 +54,14 @@ const t = {
     desc: "",
     quick: "",
     noAcc: "",
+    fName: "",
+    fDate: "",
+    fDept: "",
+    fSuccess: "",
+    fError: "",
     meet: "",
     view: "",
-    doctors: [],
+    doctors: [] as { name: string; role: string }[],
 };
 
 const baseDoctors = [
@@ -99,17 +114,58 @@ const doctors = baseDoctors.map((d, i) => ({
                 class="p-6 shadow-lg border-t-4 border-l-0 border-r-0 border-b-0 !border-t-teal-500 w-full md:w-auto min-w-[300px]"
             >
                 <h3 class="font-bold text-lg mb-4 text-center">{t.quick}</h3>
-                <Button
-                    variant="primary"
-                    class="w-full bg-teal-600 hover:bg-teal-700 text-white mb-2 py-2"
-                >
-                    {contentFocus.primaryCTA}
-                </Button>
-                <p
-                    class="text-xs text-center text-gray-400 dark:text-gray-500 mt-2"
-                >
-                    {t.noAcc}
-                </p>
+                <appointment-form class="block">
+                    <form novalidate class="space-y-3">
+                        <input
+                            data-field
+                            type="text"
+                            aria-label={t.fName}
+                            placeholder={t.fName}
+                            class="w-full border rounded px-3 py-2 text-sm bg-white dark:bg-slate-800 border-gray-300 dark:border-slate-600 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                        />
+                        <input
+                            data-field
+                            type="date"
+                            aria-label={t.fDate}
+                            class="w-full border rounded px-3 py-2 text-sm bg-white dark:bg-slate-800 border-gray-300 dark:border-slate-600 text-gray-600 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                        />
+                        <select
+                            data-field
+                            aria-label={t.fDept}
+                            class="w-full border rounded px-3 py-2 text-sm bg-white dark:bg-slate-800 border-gray-300 dark:border-slate-600 text-gray-600 dark:text-gray-300 focus:outline-none focus:ring-2 focus:ring-teal-500"
+                        >
+                            <option value="">{t.fDept}</option>
+                            {t.doctors.map((d) => (
+                                <option value={d.role}>{d.role}</option>
+                            ))}
+                        </select>
+                        <button
+                            type="submit"
+                            class="w-full bg-teal-600 hover:bg-teal-700 text-white rounded py-2 font-medium transition-colors"
+                        >
+                            {contentFocus.primaryCTA}
+                        </button>
+                    </form>
+                    <p
+                        data-error
+                        role="alert"
+                        class="hidden text-xs text-center text-red-500 mt-2"
+                    >
+                        {t.fError}
+                    </p>
+                    <p
+                        data-success
+                        role="status"
+                        class="hidden text-xs text-center text-teal-600 dark:text-teal-400 font-medium mt-2"
+                    >
+                        {t.fSuccess}
+                    </p>
+                    <p
+                        class="text-xs text-center text-gray-400 dark:text-gray-500 mt-2"
+                    >
+                        {t.noAcc}
+                    </p>
+                </appointment-form>
             </Card>
         </div>
     </div>
@@ -152,3 +208,52 @@ const doctors = baseDoctors.map((d, i) => ({
         )
     }
 </div>
+
+<script>
+    // 預約表單 Web Component:前端驗證,全部欄位填妥才顯示成功訊息。
+    // 驗證只讀 DOM 上各欄位的實際值,與 i18n 內容無關。
+    class AppointmentForm extends HTMLElement {
+        connectedCallback() {
+            const form = this.querySelector<HTMLFormElement>("form");
+            const fields =
+                this.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
+                    "[data-field]",
+                );
+            const error = this.querySelector<HTMLElement>("[data-error]");
+            const success = this.querySelector<HTMLElement>("[data-success]");
+
+            const RING = ["ring-2", "ring-red-500", "border-red-500"];
+
+            form?.addEventListener("submit", (e) => {
+                e.preventDefault();
+                let valid = true;
+                fields.forEach((f) => {
+                    const empty = !f.value.trim();
+                    f.classList.toggle("ring-2", empty);
+                    f.classList.toggle("ring-red-500", empty);
+                    f.classList.toggle("border-red-500", empty);
+                    if (empty) valid = false;
+                });
+
+                error?.classList.toggle("hidden", valid);
+                success?.classList.toggle("hidden", !valid);
+
+                if (valid) {
+                    form.reset();
+                    fields.forEach((f) => f.classList.remove(...RING));
+                }
+            });
+
+            // clear a field's error state as the user edits it
+            fields.forEach((f) => {
+                f.addEventListener("input", () =>
+                    f.classList.remove(...RING),
+                );
+            });
+        }
+    }
+
+    if (!customElements.get("appointment-form")) {
+        customElements.define("appointment-form", AppointmentForm);
+    }
+</script>

--- a/src/components/domain/corporate/NonProfitImpactLayout.astro
+++ b/src/components/domain/corporate/NonProfitImpactLayout.astro
@@ -66,13 +66,18 @@ const t = {
     <!-- Impact Data Section -->
     {
         contentFocus.showImpactData && (
-            <div class="max-w-6xl mx-auto px-6 -mt-16 relative z-10">
+            <count-up class="block max-w-6xl mx-auto px-6 -mt-16 relative z-10">
                 <Card
                     variant="default"
                     class="!shadow-xl p-8 grid md:grid-cols-3 gap-8 text-center !border-b-4 !border-sky-500 border-x-0 border-t-0"
                 >
                     <div class="p-4">
-                        <div class="text-4xl font-extrabold text-sky-600 mb-2">
+                        <div
+                            data-count
+                            data-target="50"
+                            data-suffix="K+"
+                            class="text-4xl font-extrabold text-sky-600 mb-2"
+                        >
                             50K+
                         </div>
                         <div class="text-gray-600 dark:text-gray-300 font-medium">
@@ -80,7 +85,12 @@ const t = {
                         </div>
                     </div>
                     <div class="p-4 md:border-l md:border-r border-gray-100 dark:border-slate-700">
-                        <div class="text-4xl font-extrabold text-sky-600 mb-2">
+                        <div
+                            data-count
+                            data-target="120"
+                            data-suffix=""
+                            class="text-4xl font-extrabold text-sky-600 mb-2"
+                        >
                             120
                         </div>
                         <div class="text-gray-600 dark:text-gray-300 font-medium">
@@ -88,7 +98,12 @@ const t = {
                         </div>
                     </div>
                     <div class="p-4">
-                        <div class="text-4xl font-extrabold text-sky-600 mb-2">
+                        <div
+                            data-count
+                            data-target="95"
+                            data-suffix="%"
+                            class="text-4xl font-extrabold text-sky-600 mb-2"
+                        >
                             95%
                         </div>
                         <div class="text-gray-600 dark:text-gray-300 font-medium">
@@ -96,7 +111,7 @@ const t = {
                         </div>
                     </div>
                 </Card>
-            </div>
+            </count-up>
         )
     }
 
@@ -147,3 +162,59 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 影響力數字 count-up Web Component:捲入視窗時從 0 動畫到目標值。
+    // 目標值與後綴存在 DOM 的 data-target / data-suffix 上,script 只讀 DOM。
+    class CountUp extends HTMLElement {
+        private observer: IntersectionObserver | null = null;
+        private done = false;
+
+        connectedCallback() {
+            const nodes = this.querySelectorAll<HTMLElement>("[data-count]");
+            // reset to 0 so the animation has somewhere to travel from
+            nodes.forEach((n) => {
+                n.textContent = `0${n.dataset.suffix ?? ""}`;
+            });
+
+            const animate = () => {
+                if (this.done) return;
+                this.done = true;
+                nodes.forEach((n) => {
+                    const target = Number(n.dataset.target ?? "0");
+                    const suffix = n.dataset.suffix ?? "";
+                    const duration = 1200;
+                    const start = performance.now();
+                    const tick = (now: number) => {
+                        const p = Math.min((now - start) / duration, 1);
+                        const eased = 1 - Math.pow(1 - p, 3); // easeOutCubic
+                        n.textContent = `${Math.round(eased * target)}${suffix}`;
+                        if (p < 1) requestAnimationFrame(tick);
+                    };
+                    requestAnimationFrame(tick);
+                });
+            };
+
+            if ("IntersectionObserver" in window) {
+                this.observer = new IntersectionObserver(
+                    (entries) => {
+                        if (entries.some((e) => e.isIntersecting)) animate();
+                    },
+                    { threshold: 0.4 },
+                );
+                this.observer.observe(this);
+            } else {
+                animate();
+            }
+        }
+
+        disconnectedCallback() {
+            this.observer?.disconnect();
+            this.observer = null;
+        }
+    }
+
+    if (!customElements.get("count-up")) {
+        customElements.define("count-up", CountUp);
+    }
+</script>

--- a/src/components/domain/corporate/RestaurantVisualLayout.astro
+++ b/src/components/domain/corporate/RestaurantVisualLayout.astro
@@ -15,10 +15,31 @@ const t = {
     en: {
         tag: "Fine Dining Experience",
         menuTitle: "Chef's Tasting Menu",
-        items: [
-            { name: "Wagyu Beef Tartare", price: "$24" },
-            { name: "Pan Seared Scallops", price: "$32" },
-            { name: "Truffle Risotto", price: "$28" },
+        menu: [
+            {
+                cat: "Starters",
+                items: [
+                    { name: "Wagyu Beef Tartare", price: "$24" },
+                    { name: "Pan Seared Scallops", price: "$32" },
+                    { name: "Burrata & Heirloom Tomato", price: "$18" },
+                ],
+            },
+            {
+                cat: "Mains",
+                items: [
+                    { name: "Truffle Risotto", price: "$28" },
+                    { name: "Dry-Aged Ribeye", price: "$46" },
+                    { name: "Miso Black Cod", price: "$38" },
+                ],
+            },
+            {
+                cat: "Desserts",
+                items: [
+                    { name: "Valrhona Chocolate Fondant", price: "$14" },
+                    { name: "Yuzu Cheesecake", price: "$12" },
+                    { name: "Seasonal Sorbet", price: "$10" },
+                ],
+            },
         ],
         hoursLabel: "Opening Hours",
         hours: "Mon-Sun: 17:00 - 23:00",
@@ -26,10 +47,31 @@ const t = {
     "zh-tw": {
         tag: "精緻餐飲體驗",
         menuTitle: "主廚品嚐菜單",
-        items: [
-            { name: "和牛塔塔", price: "$24" },
-            { name: "香煎干貝", price: "$32" },
-            { name: "松露燉飯", price: "$28" },
+        menu: [
+            {
+                cat: "前菜",
+                items: [
+                    { name: "和牛塔塔", price: "$24" },
+                    { name: "香煎干貝", price: "$32" },
+                    { name: "布拉塔起司與傳家番茄", price: "$18" },
+                ],
+            },
+            {
+                cat: "主菜",
+                items: [
+                    { name: "松露燉飯", price: "$28" },
+                    { name: "乾式熟成肋眼", price: "$46" },
+                    { name: "味噌黑鱈", price: "$38" },
+                ],
+            },
+            {
+                cat: "甜點",
+                items: [
+                    { name: "Valrhona 巧克力熔岩", price: "$14" },
+                    { name: "柚子起司蛋糕", price: "$12" },
+                    { name: "時令雪酪", price: "$10" },
+                ],
+            },
         ],
         hoursLabel: "營業時間",
         hours: "週一至週日: 17:00 - 23:00",
@@ -37,7 +79,7 @@ const t = {
 }[lang] || {
     tag: "",
     menuTitle: "",
-    items: [],
+    menu: [] as { cat: string; items: { name: string; price: string }[] }[],
     hoursLabel: "",
     hours: "",
 };
@@ -73,28 +115,48 @@ const t = {
             {contentFocus.title}
         </h2>
 
-        <Card
-            variant="default"
-            class="!bg-white/60 dark:!bg-white/5 backdrop-blur-md border border-stone-200 dark:border-white/10 p-8 rounded-lg max-w-2xl w-full mb-12 shadow-xl dark:shadow-none"
-        >
-            <h3
-                class="text-2xl mb-6 text-amber-700 dark:text-amber-200 border-b border-stone-300 dark:border-white/10 pb-4"
+        <menu-tabs class="block max-w-2xl w-full mb-12">
+            <Card
+                variant="default"
+                class="!bg-white/60 dark:!bg-white/5 backdrop-blur-md border border-stone-200 dark:border-white/10 p-8 rounded-lg w-full shadow-xl dark:shadow-none"
             >
-                {t.menuTitle}
-            </h3>
-            <ul class="space-y-4 text-lg">
-                {
-                    t.items.map((item: any) => (
-                        <li class="flex justify-between">
-                            <span class="font-medium">{item.name}</span>
-                            <span class="text-stone-500 dark:text-stone-400">
-                                ................... {item.price}
-                            </span>
-                        </li>
-                    ))
-                }
-            </ul>
-        </Card>
+                <h3
+                    class="text-2xl mb-6 text-amber-700 dark:text-amber-200 border-b border-stone-300 dark:border-white/10 pb-4"
+                >
+                    {t.menuTitle}
+                </h3>
+
+                {/* Category tabs */}
+                <div class="flex justify-center gap-2 mb-6">
+                    {t.menu.map((section, i) => (
+                        <button
+                            type="button"
+                            data-cat={section.cat}
+                            aria-pressed={i === 0 ? "true" : "false"}
+                            class="px-4 py-1.5 rounded-full text-sm uppercase tracking-wider font-bold text-stone-500 dark:text-stone-400 transition-colors"
+                        >
+                            {section.cat}
+                        </button>
+                    ))}
+                </div>
+
+                {t.menu.map((section, i) => (
+                    <ul
+                        data-panel={section.cat}
+                        class={`space-y-4 text-lg ${i === 0 ? "" : "hidden"}`}
+                    >
+                        {section.items.map((item) => (
+                            <li class="flex justify-between">
+                                <span class="font-medium">{item.name}</span>
+                                <span class="text-stone-500 dark:text-stone-400">
+                                    ................... {item.price}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                ))}
+            </Card>
+        </menu-tabs>
 
         <div class="flex flex-col md:flex-row gap-6 items-center">
             <Button
@@ -114,3 +176,48 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 菜單分類 tab Web Component:切換前菜/主菜/甜點清單。
+    // 以 data-cat(按鈕)對應 data-panel(清單),狀態存在 DOM。
+    class MenuTabs extends HTMLElement {
+        connectedCallback() {
+            const tabs = this.querySelectorAll<HTMLButtonElement>("[data-cat]");
+            const panels = this.querySelectorAll<HTMLElement>("[data-panel]");
+
+            const ACTIVE = [
+                "bg-amber-600",
+                "text-white",
+                "dark:bg-amber-500",
+            ];
+
+            const select = (cat: string) => {
+                tabs.forEach((tab) => {
+                    const on = tab.dataset.cat === cat;
+                    tab.setAttribute("aria-pressed", String(on));
+                    on
+                        ? tab.classList.add(...ACTIVE)
+                        : tab.classList.remove(...ACTIVE);
+                });
+                panels.forEach((panel) => {
+                    panel.classList.toggle(
+                        "hidden",
+                        panel.dataset.panel !== cat,
+                    );
+                });
+            };
+
+            tabs.forEach((tab) => {
+                tab.addEventListener("click", () =>
+                    select(tab.dataset.cat ?? ""),
+                );
+            });
+
+            if (tabs[0]) select(tabs[0].dataset.cat ?? "");
+        }
+    }
+
+    if (!customElements.get("menu-tabs")) {
+        customElements.define("menu-tabs", MenuTabs);
+    }
+</script>

--- a/src/components/domain/corporate/StrictProfessionalLayout.astro
+++ b/src/components/domain/corporate/StrictProfessionalLayout.astro
@@ -15,11 +15,26 @@ const t = {
     en: {
         areas: "Practice Areas",
         areaList: [
-            "Corporate Law",
-            "Mergers & Acquisitions",
-            "Taxation Strategy",
-            "Intellectual Property",
-            "Litigation",
+            {
+                name: "Corporate Law",
+                blurb: "Entity formation, governance, and day-to-day counsel for boards and executives.",
+            },
+            {
+                name: "Mergers & Acquisitions",
+                blurb: "Buy-side and sell-side deal execution, due diligence, and antitrust clearance.",
+            },
+            {
+                name: "Taxation Strategy",
+                blurb: "Cross-border structuring that keeps multinational operations efficient and compliant.",
+            },
+            {
+                name: "Intellectual Property",
+                blurb: "Portfolio strategy, licensing, and enforcement for technology and brand assets.",
+            },
+            {
+                name: "Litigation",
+                blurb: "Commercial disputes and regulatory defense, from negotiation through trial.",
+            },
         ],
         contact: "Contact Us",
         intro: "We provide comprehensive legal counsel to multinational corporations and financial institutions. Our approach is rooted in a deep understanding of regulatory frameworks and a commitment to achieving favorable outcomes.",
@@ -38,7 +53,28 @@ const t = {
     },
     "zh-tw": {
         areas: "專業領域",
-        areaList: ["公司法", "企業併購", "稅務策略", "智慧財產權", "訴訟"],
+        areaList: [
+            {
+                name: "公司法",
+                blurb: "為董事會與經營團隊提供公司設立、治理與日常法律諮詢。",
+            },
+            {
+                name: "企業併購",
+                blurb: "買賣雙方交易執行、盡職調查與反壟斷審查。",
+            },
+            {
+                name: "稅務策略",
+                blurb: "跨國架構規劃，兼顧營運效率與法規遵循。",
+            },
+            {
+                name: "智慧財產權",
+                blurb: "科技與品牌資產的專利佈局、授權與權利執行。",
+            },
+            {
+                name: "訴訟",
+                blurb: "商業爭議與法規辯護，從協商到審判全程代理。",
+            },
+        ],
         contact: "聯絡我們",
         intro: "我們為跨國企業和金融機構提供全面的法律諮詢。我們的方法植基於對監管框架的深刻理解，並致力於達成最有利的結果。",
         cases: [
@@ -56,7 +92,7 @@ const t = {
     },
 }[lang] || {
     areas: "",
-    areaList: [],
+    areaList: [] as { name: string; blurb: string }[],
     contact: "",
     intro: "",
     cases: [],
@@ -68,8 +104,8 @@ const t = {
 <div
     class="bg-white dark:bg-slate-900 text-slate-900 dark:text-white font-serif p-8 md:p-12 transition-colors duration-300 min-h-screen"
 >
-    <div class="max-w-6xl mx-auto flex flex-col md:flex-row gap-12">
-        <!-- Sidebar Navigation (Visual Only) -->
+    <area-tabs class="max-w-6xl mx-auto flex flex-col md:flex-row gap-12">
+        <!-- Sidebar Navigation -->
         {
             contentFocus.deepNavigation && (
                 <div class="w-full md:w-64 border-r border-slate-200 dark:border-slate-700 pr-8 hidden md:block">
@@ -77,12 +113,17 @@ const t = {
                         {t.areas}
                     </div>
                     <ul class="space-y-4 text-sm text-slate-600 dark:text-slate-400">
-                        <li class="font-bold text-slate-900 dark:text-white border-l-2 border-slate-900 dark:border-white pl-3">
-                            {t.areaList[0]}
-                        </li>
-                        {t.areaList.slice(1).map((area: string) => (
-                            <li class="pl-3 hover:text-slate-900 dark:hover:text-white cursor-pointer transition-colors">
-                                {area}
+                        {t.areaList.map((area, i) => (
+                            <li>
+                                <button
+                                    type="button"
+                                    data-area
+                                    data-blurb={area.blurb}
+                                    aria-pressed={i === 0 ? "true" : "false"}
+                                    class="w-full text-left pl-3 hover:text-slate-900 dark:hover:text-white cursor-pointer transition-colors"
+                                >
+                                    {area.name}
+                                </button>
                             </li>
                         ))}
                     </ul>
@@ -112,10 +153,27 @@ const t = {
             </h2>
 
             <p
-                class="text-lg text-slate-700 dark:text-slate-300 leading-relaxed mb-8"
+                class="text-lg text-slate-700 dark:text-slate-300 leading-relaxed mb-6"
             >
                 {t.intro}
             </p>
+
+            <div
+                class="border-l-4 border-slate-900 dark:border-white pl-4 mb-8"
+            >
+                <p
+                    data-area-title
+                    class="font-bold text-slate-900 dark:text-white"
+                >
+                    {t.areaList[0]?.name}
+                </p>
+                <p
+                    data-area-blurb
+                    class="text-slate-600 dark:text-slate-300"
+                >
+                    {t.areaList[0]?.blurb}
+                </p>
+            </div>
 
             <div class="grid md:grid-cols-2 gap-8 mb-12">
                 {
@@ -151,5 +209,49 @@ const t = {
                 </Button>
             </div>
         </div>
-    </div>
+    </area-tabs>
 </div>
+
+<script>
+    // 執業領域 tab Web Component:點側欄領域,主內容顯示對應說明。
+    // 領域說明存在按鈕的文字與 data-blurb 上,狀態存在 DOM。
+    class AreaTabs extends HTMLElement {
+        connectedCallback() {
+            const buttons = this.querySelectorAll<HTMLButtonElement>("[data-area]");
+            const title = this.querySelector<HTMLElement>("[data-area-title]");
+            const blurb = this.querySelector<HTMLElement>("[data-area-blurb]");
+
+            const ACTIVE = [
+                "font-bold",
+                "text-slate-900",
+                "dark:text-white",
+                "border-l-2",
+                "border-slate-900",
+                "dark:border-white",
+            ];
+
+            const select = (btn: HTMLButtonElement) => {
+                buttons.forEach((b) => {
+                    const on = b === btn;
+                    b.setAttribute("aria-pressed", String(on));
+                    on
+                        ? b.classList.add(...ACTIVE)
+                        : b.classList.remove(...ACTIVE);
+                });
+                if (title) title.textContent = btn.textContent?.trim() ?? "";
+                if (blurb && btn.dataset.blurb)
+                    blurb.textContent = btn.dataset.blurb;
+            };
+
+            buttons.forEach((btn) => {
+                btn.addEventListener("click", () => select(btn));
+            });
+
+            if (buttons[0]) select(buttons[0]);
+        }
+    }
+
+    if (!customElements.get("area-tabs")) {
+        customElements.define("area-tabs", AreaTabs);
+    }
+</script>


### PR DESCRIPTION
## Summary

Third batch of the showcase interaction pass (`docs/specs/showcase-interaction-pass-spec.md`, added in #24): the 5 **corporate** category demo layouts each gain one signature native Web Component interaction. Content was already domain-coherent bilingual mock but every layout was 100% static. As with the software batch, this is the interaction layer only — no content collection — with all state driven from DOM `data-*` so a future data-source swap is a template change that leaves the JS untouched.

This batch also introduces two new reusable primitives — a **validated form** and an **IntersectionObserver count-up** — alongside the tabs/stepper shape from the software batch.

## Interactions added

| Layout | Interaction | Element |
|---|---|---|
| `IndustrialModularLayout` | Process stepper — click a stage to reveal its detail | `<process-stepper>` |
| `MedicalClinicLayout` | Front-end-validated appointment form (inline error/success) | `<appointment-form>` |
| `NonProfitImpactLayout` | Impact stats count up from 0 on scroll | `<count-up>` |
| `RestaurantVisualLayout` | Menu category tabs (Starters / Mains / Desserts) | `<menu-tabs>` |
| `StrictProfessionalLayout` | Sidebar practice-area tabs swap a detail panel | `<area-tabs>` |

All mirror the established pattern: hyphenated root wrapper, guarded `customElements.define`, listeners bound in `connectedCallback` (re-bind across View Transitions; `count-up` disconnects its observer in `disconnectedCallback`), accessible triggers (`aria-pressed`, real `<button>`s, form `role="alert"`/`role="status"`).

Where an interaction needed more than one state's worth of data, the mock `t` was enriched in **both** locales (step descriptions, categorized menu, per-area blurbs) and rendered into the DOM as `data-*` — never read from the JS object at runtime.

## Acceptance criteria (spec §6)

- [x] `npm run build` green; `astro check` 0 errors (only pre-existing hints)
- [x] All 5 interactions work in both locales across all 10 routes
- [x] Every interaction survives a View Transition (verified: SPA-nav to another corporate theme, interaction still responds)
- [x] Zero interaction state read from the JS `t` object — all read from DOM `data-*`
- [x] No hardcoded counts/categories in JS
- [x] `package.json` untouched — zero new runtime frameworks
- [x] Conventional Commits, one `feat(corporate)` commit per layout

## Test plan

- `npm run dev`, visit `/{en,zh-tw}/explore/corporate/{ManufacturingB2B,MedicalClinic,NonProfitNGO,RestaurantCafe,LawAccountingFirm}`
- Step through the process flow, submit the appointment form (empty → error; filled → success), scroll to the impact stats (count-up), switch menu categories, select practice areas
- Navigate away via ThemeDock and back — every interaction must still respond

Automated end-to-end verification (headless Edge) drove all 5 interactions + the View-Transition-survival case: **9/9 assertions pass**; a separate zh-tw smoke run confirms hydration and content parity across all 5 zh-tw routes.

## Scope note

`ecommerce` and `contentNews` follow in later batches and reuse these primitives (tabs, accordion, form, count-up). The shared spec lives in #24; if that merges after this, the spec simply lands on `main` alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
