### PR TITLE
feat(ecommerce): add signature Web Component interactions to the 5 ecommerce layouts

### DIFF
--- a/src/components/domain/ecommerce/DigitalProductLayout.astro
+++ b/src/components/domain/ecommerce/DigitalProductLayout.astro
@@ -23,8 +23,41 @@ const t = {
         preview: "Preview: Course Intro",
         payment: "One-time payment",
         curriculum: "Course Curriculum",
-        unit: "Module",
-        topic: "Advanced Concepts",
+        lessonsWord: "lessons",
+        modules: [
+            {
+                title: "Foundations",
+                lessons: [
+                    { name: "Getting Set Up", time: "08:20" },
+                    { name: "Core Principles", time: "12:45" },
+                    { name: "Your First Project", time: "15:00" },
+                ],
+            },
+            {
+                title: "Building Blocks",
+                lessons: [
+                    { name: "Components in Depth", time: "14:10" },
+                    { name: "State & Data Flow", time: "16:30" },
+                    { name: "Reusable Patterns", time: "11:05" },
+                ],
+            },
+            {
+                title: "Advanced Techniques",
+                lessons: [
+                    { name: "Performance Tuning", time: "18:40" },
+                    { name: "Testing Strategy", time: "13:15" },
+                    { name: "Debugging Like a Pro", time: "10:50" },
+                ],
+            },
+            {
+                title: "Shipping to Production",
+                lessons: [
+                    { name: "Deployment Pipeline", time: "12:00" },
+                    { name: "Monitoring & Alerts", time: "09:35" },
+                    { name: "Course Wrap-Up", time: "06:20" },
+                ],
+            },
+        ],
     },
     "zh-tw": {
         tag: "大師班",
@@ -36,8 +69,41 @@ const t = {
         preview: "預覽：課程介紹",
         payment: "一次性付款",
         curriculum: "課程大綱",
-        unit: "單元",
-        topic: "進階概念",
+        lessonsWord: "堂課",
+        modules: [
+            {
+                title: "基礎建立",
+                lessons: [
+                    { name: "環境設定", time: "08:20" },
+                    { name: "核心原則", time: "12:45" },
+                    { name: "你的第一個專案", time: "15:00" },
+                ],
+            },
+            {
+                title: "構成元件",
+                lessons: [
+                    { name: "深入元件", time: "14:10" },
+                    { name: "狀態與資料流", time: "16:30" },
+                    { name: "可重用模式", time: "11:05" },
+                ],
+            },
+            {
+                title: "進階技巧",
+                lessons: [
+                    { name: "效能調校", time: "18:40" },
+                    { name: "測試策略", time: "13:15" },
+                    { name: "專業除錯", time: "10:50" },
+                ],
+            },
+            {
+                title: "上線部署",
+                lessons: [
+                    { name: "部署流程", time: "12:00" },
+                    { name: "監控與告警", time: "09:35" },
+                    { name: "課程總結", time: "06:20" },
+                ],
+            },
+        ],
     },
 }[lang] || {
     tag: "",
@@ -45,8 +111,11 @@ const t = {
     preview: "",
     payment: "",
     curriculum: "",
-    unit: "",
-    topic: "",
+    lessonsWord: "",
+    modules: [] as {
+        title: string;
+        lessons: { name: string; time: string }[];
+    }[],
 };
 ---
 
@@ -123,29 +192,110 @@ const t = {
                 >
                     {t.curriculum}
                 </h3>
-                <div class="space-y-2">
+                <curriculum-accordion class="block space-y-2">
                     {
-                        [1, 2, 3, 4].map((unit) => (
-                            <Card
-                                variant="hover"
-                                class="flex flex-row items-center justify-between !p-4 !bg-gray-50 dark:!bg-slate-800 rounded hover:!bg-indigo-50 dark:hover:!bg-slate-700 cursor-pointer group border-none shadow-none"
-                            >
-                                <div class="flex items-center gap-3">
-                                    <div class="w-6 h-6 rounded-full border border-indigo-300 flex items-center justify-center text-xs text-indigo-600 font-bold group-hover:bg-indigo-600 group-hover:text-white transition-colors">
-                                        {unit}
+                        t.modules.map((module, i) => {
+                            const open = i === 0;
+                            return (
+                                <div class="!bg-gray-50 dark:!bg-slate-800 rounded overflow-hidden">
+                                    <button
+                                        type="button"
+                                        data-accordion-trigger
+                                        aria-expanded={open ? "true" : "false"}
+                                        class="w-full flex items-center justify-between p-4 text-left hover:bg-indigo-50 dark:hover:bg-slate-700 transition-colors"
+                                    >
+                                        <span class="flex items-center gap-3">
+                                            <span class="w-6 h-6 rounded-full border border-indigo-300 flex items-center justify-center text-xs text-indigo-600 font-bold flex-shrink-0">
+                                                {i + 1}
+                                            </span>
+                                            <span class="font-medium text-gray-700 dark:text-gray-200">
+                                                {module.title}
+                                            </span>
+                                        </span>
+                                        <span class="flex items-center gap-3 text-gray-400 dark:text-gray-500 text-sm">
+                                            {module.lessons.length} {t.lessonsWord}
+                                            <svg
+                                                data-accordion-icon
+                                                class={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+                                                fill="none"
+                                                viewBox="0 0 24 24"
+                                                stroke="currentColor"
+                                                stroke-width="2"
+                                            >
+                                                <path
+                                                    stroke-linecap="round"
+                                                    stroke-linejoin="round"
+                                                    d="M19 9l-7 7-7-7"
+                                                />
+                                            </svg>
+                                        </span>
+                                    </button>
+                                    <div
+                                        data-accordion-panel
+                                        class={open ? "" : "hidden"}
+                                    >
+                                        <ul class="px-4 pb-3 pl-9 space-y-2">
+                                            {module.lessons.map((lesson) => (
+                                                <li class="flex items-center justify-between text-sm text-gray-600 dark:text-gray-300 border-t border-gray-100 dark:border-slate-700 pt-2">
+                                                    <span class="flex items-center gap-2">
+                                                        <svg
+                                                            class="w-4 h-4 text-indigo-400 flex-shrink-0"
+                                                            fill="none"
+                                                            viewBox="0 0 24 24"
+                                                            stroke="currentColor"
+                                                            stroke-width="2"
+                                                        >
+                                                            <path
+                                                                stroke-linecap="round"
+                                                                stroke-linejoin="round"
+                                                                d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+                                                            />
+                                                        </svg>
+                                                        {lesson.name}
+                                                    </span>
+                                                    <span class="text-gray-400 dark:text-gray-500">
+                                                        {lesson.time}
+                                                    </span>
+                                                </li>
+                                            ))}
+                                        </ul>
                                     </div>
-                                    <span class="font-medium text-gray-700 dark:text-gray-200">
-                                        {t.unit} {unit}: {t.topic}
-                                    </span>
                                 </div>
-                                <span class="text-gray-400 dark:text-gray-500 text-sm">
-                                    15:00
-                                </span>
-                            </Card>
-                        ))
+                            );
+                        })
                     }
-                </div>
+                </curriculum-accordion>
             </div>
         </Card>
     </div>
 </div>
+
+<script>
+    // 課程大綱手風琴 Web Component:點模組展開/收合課程清單。
+    // 展開狀態由 DOM(aria-expanded + panel 的 hidden class)驅動。
+    class CurriculumAccordion extends HTMLElement {
+        connectedCallback() {
+            const triggers = this.querySelectorAll<HTMLButtonElement>(
+                "[data-accordion-trigger]",
+            );
+
+            triggers.forEach((trigger) => {
+                trigger.addEventListener("click", () => {
+                    const expanded =
+                        trigger.getAttribute("aria-expanded") === "true";
+                    const panel = trigger.nextElementSibling;
+                    const icon = trigger.querySelector<SVGElement>(
+                        "[data-accordion-icon]",
+                    );
+                    trigger.setAttribute("aria-expanded", String(!expanded));
+                    panel?.classList.toggle("hidden", expanded);
+                    icon?.classList.toggle("rotate-180", !expanded);
+                });
+            });
+        }
+    }
+
+    if (!customElements.get("curriculum-accordion")) {
+        customElements.define("curriculum-accordion", CurriculumAccordion);
+    }
+</script>

--- a/src/components/domain/ecommerce/EditorialMagazineLayout.astro
+++ b/src/components/domain/ecommerce/EditorialMagazineLayout.astro
@@ -36,6 +36,15 @@ const t = {
     item2: "",
     cta: "",
 };
+
+// Gallery images are language-independent, so they live outside `t`.
+// The <image-gallery> element reads the DOM (thumbnail data-src), never this.
+const gallery = [
+    "https://picsum.photos/800/1200?random=editorial1",
+    "https://picsum.photos/800/1200?random=editorial2",
+    "https://picsum.photos/800/1200?random=editorial3",
+    "https://picsum.photos/800/1200?random=editorial4",
+];
 ---
 
 <div
@@ -43,22 +52,46 @@ const t = {
 >
     <!-- Main Grid Container -->
     <div class="grid md:grid-cols-2 min-h-[600px]">
-        <!-- Left: Hero Image -->
-        <div class="relative h-96 md:h-auto overflow-hidden group">
+        <!-- Left: Hero Image Gallery -->
+        <image-gallery
+            class="relative block h-96 md:h-auto overflow-hidden group"
+        >
             <img
-                src="https://picsum.photos/800/1200?random=fashion"
+                data-gallery-main
+                src={gallery[0]}
                 alt="Fashion Editorial"
                 class="w-full h-full object-cover grayscale group-hover:grayscale-0 transition-all duration-700 ease-in-out"
             />
-            <div class="absolute bottom-8 left-8">
-                <p class="text-white text-xs tracking-[0.3em] uppercase mb-2">
+
+            {/* Thumbnails */}
+            <div class="absolute top-4 right-4 flex flex-col gap-2 z-10">
+                {gallery.map((src, i) => (
+                    <button
+                        type="button"
+                        data-gallery-thumb
+                        data-src={src}
+                        aria-pressed={i === 0 ? "true" : "false"}
+                        aria-label={`View image ${i + 1}`}
+                        class="w-12 h-16 overflow-hidden ring-2 ring-transparent transition-all"
+                    >
+                        <img
+                            src={src}
+                            alt=""
+                            class="w-full h-full object-cover"
+                        />
+                    </button>
+                ))}
+            </div>
+
+            <div class="absolute bottom-8 left-8 z-10">
+                <p class="text-white text-xs tracking-[0.3em] uppercase mb-2 drop-shadow">
                     {t.season}
                 </p>
-                <h2 class="text-white text-4xl font-serif italic">
+                <h2 class="text-white text-4xl font-serif italic drop-shadow">
                     {t.heroTitle}
                 </h2>
             </div>
-        </div>
+        </image-gallery>
 
         <!-- Right: Content & Grid -->
         <div class="p-12 flex flex-col justify-center">
@@ -115,3 +148,41 @@ const t = {
         </div>
     </div>
 </div>
+
+<script>
+    // 圖片畫廊 Web Component:點縮圖切換主圖。
+    // 圖片來源存在縮圖的 data-src 上,script 只讀 DOM。
+    class ImageGallery extends HTMLElement {
+        connectedCallback() {
+            const main = this.querySelector<HTMLImageElement>(
+                "[data-gallery-main]",
+            );
+            const thumbs = this.querySelectorAll<HTMLButtonElement>(
+                "[data-gallery-thumb]",
+            );
+
+            const ACTIVE = ["ring-white"];
+
+            const select = (thumb: HTMLButtonElement) => {
+                if (main && thumb.dataset.src) main.src = thumb.dataset.src;
+                thumbs.forEach((t) => {
+                    const on = t === thumb;
+                    t.setAttribute("aria-pressed", String(on));
+                    on
+                        ? t.classList.add(...ACTIVE)
+                        : t.classList.remove(...ACTIVE);
+                });
+            };
+
+            thumbs.forEach((thumb) => {
+                thumb.addEventListener("click", () => select(thumb));
+            });
+
+            if (thumbs[0]) select(thumbs[0]);
+        }
+    }
+
+    if (!customElements.get("image-gallery")) {
+        customElements.define("image-gallery", ImageGallery);
+    }
+</script>

--- a/src/components/domain/ecommerce/FoodGroceryLayout.astro
+++ b/src/components/domain/ecommerce/FoodGroceryLayout.astro
@@ -29,6 +29,8 @@ const t = {
         boxTitle: "Weekly Harvest Box",
         boxDesc: "Get 20% off your first subscription order.",
         boxBtn: "Subscribe",
+        added: "Added to cart",
+        cartLabel: "Cart",
     },
     "zh-tw": {
         desc: "從在地農場新鮮直送餐桌。",
@@ -42,6 +44,8 @@ const t = {
         boxTitle: "每週豐收箱",
         boxDesc: "首次訂閱享八折優惠。",
         boxBtn: "訂閱",
+        added: "已加入購物車",
+        cartLabel: "購物車",
     },
 }[lang] || {
     desc: "",
@@ -50,6 +54,8 @@ const t = {
     boxTitle: "",
     boxDesc: "",
     boxBtn: "",
+    added: "",
+    cartLabel: "",
 };
 
 const baseProducts = [
@@ -75,8 +81,8 @@ const badgeVariants: Record<
 };
 ---
 
-<div
-    class="bg-green-50 dark:bg-green-950/30 p-8 font-sans transition-colors duration-300 min-h-screen"
+<add-to-cart
+    class="block bg-green-50 dark:bg-green-950/30 p-8 font-sans transition-colors duration-300 min-h-screen"
 >
     <!-- Header -->
     <div
@@ -88,22 +94,45 @@ const badgeVariants: Record<
             </h2>
             <p class="text-green-700 dark:text-green-300">{t.desc}</p>
         </div>
-        <div class="hidden md:flex gap-2">
-            {
-                t.cats &&
-                    t.cats.map((cat: string, index: number) => (
-                        <Badge
-                            variant={index === 2 ? "primary" : "neutral"}
-                            class={`px-3 py-1 cursor-pointer border ${
-                                index === 2
-                                    ? "!bg-green-600 !text-white !border-none"
-                                    : "!bg-white dark:!bg-green-900 hover:!bg-green-100 dark:hover:!bg-green-800 !border-green-200 dark:!border-green-800 !text-green-800 dark:!text-green-100"
-                            }`}
-                        >
-                            {cat}
-                        </Badge>
-                    ))
-            }
+        <div class="flex items-center gap-4">
+            <div class="hidden md:flex gap-2">
+                {
+                    t.cats &&
+                        t.cats.map((cat: string, index: number) => (
+                            <Badge
+                                variant={index === 2 ? "primary" : "neutral"}
+                                class={`px-3 py-1 cursor-pointer border ${
+                                    index === 2
+                                        ? "!bg-green-600 !text-white !border-none"
+                                        : "!bg-white dark:!bg-green-900 hover:!bg-green-100 dark:hover:!bg-green-800 !border-green-200 dark:!border-green-800 !text-green-800 dark:!text-green-100"
+                                }`}
+                            >
+                                {cat}
+                            </Badge>
+                        ))
+                }
+            </div>
+            <div class="relative" aria-label={t.cartLabel}>
+                <svg
+                    class="w-7 h-7 text-green-800 dark:text-green-100"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="1.8"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+                    />
+                </svg>
+                <span
+                    data-cart-count
+                    class="hidden absolute -top-2 -right-2 bg-green-600 text-white text-xs font-bold rounded-full min-w-[1.25rem] h-5 px-1 items-center justify-center"
+                >
+                    0
+                </span>
+            </div>
         </div>
     </div>
 
@@ -146,6 +175,7 @@ const badgeVariants: Record<
                         </div>
                         <Button
                             variant="primary"
+                            data-add-to-cart
                             class="w-full !bg-green-600 hover:!bg-green-700 text-white rounded-lg mt-2 py-1 text-sm"
                         >
                             {contentFocus.primaryCTA}
@@ -173,6 +203,7 @@ const badgeVariants: Record<
                 </div>
                 <Button
                     variant="primary"
+                    data-add-to-cart
                     class="!bg-orange-500 hover:!bg-orange-600 text-white px-6 py-2 font-bold"
                 >
                     {t.boxBtn}
@@ -180,4 +211,60 @@ const badgeVariants: Record<
             </Card>
         )
     }
-</div>
+
+    {/* Toast */}
+    <div
+        data-toast
+        role="status"
+        class="fixed bottom-6 right-6 z-50 bg-green-700 text-white text-sm font-medium px-5 py-3 rounded-lg shadow-xl opacity-0 translate-y-4 pointer-events-none transition-all duration-300"
+    >
+        {t.added}
+    </div>
+</add-to-cart>
+
+<script>
+    // 加入購物車 Web Component:計數 +1、頂部 badge 更新、跳出 toast。
+    // 計數為元件內部狀態,由實際點擊次數累加,不從資料寫死。
+    class AddToCart extends HTMLElement {
+        private count = 0;
+        private toastTimer: number | undefined;
+
+        connectedCallback() {
+            const buttons =
+                this.querySelectorAll<HTMLElement>("[data-add-to-cart]");
+            const badge = this.querySelector<HTMLElement>("[data-cart-count]");
+            const toast = this.querySelector<HTMLElement>("[data-toast]");
+
+            buttons.forEach((btn) => {
+                btn.addEventListener("click", () => {
+                    this.count += 1;
+                    if (badge) {
+                        badge.textContent = String(this.count);
+                        badge.classList.remove("hidden");
+                        badge.classList.add("flex");
+                    }
+                    this.showToast(toast);
+                });
+            });
+        }
+
+        private showToast(toast: HTMLElement | null) {
+            if (!toast) return;
+            toast.classList.remove("opacity-0", "translate-y-4");
+            toast.classList.add("opacity-100", "translate-y-0");
+            if (this.toastTimer) window.clearTimeout(this.toastTimer);
+            this.toastTimer = window.setTimeout(() => {
+                toast.classList.add("opacity-0", "translate-y-4");
+                toast.classList.remove("opacity-100", "translate-y-0");
+            }, 1600);
+        }
+
+        disconnectedCallback() {
+            if (this.toastTimer) window.clearTimeout(this.toastTimer);
+        }
+    }
+
+    if (!customElements.get("add-to-cart")) {
+        customElements.define("add-to-cart", AddToCart);
+    }
+</script>

--- a/src/components/domain/ecommerce/SubscriptionLandingLayout.astro
+++ b/src/components/domain/ecommerce/SubscriptionLandingLayout.astro
@@ -16,10 +16,16 @@ const t = {
     en: {
         tag: "Monthly Goodness",
         desc: "Curated boxes delivered to your doorstep. Choose the plan that fits your lifestyle.",
+        monthly: "Monthly",
+        annual: "Annual",
+        save: "2 months free",
+        perMo: "/mo",
+        perYr: "/yr",
         plans: [
             {
                 name: "Starter Box",
                 price: "$29",
+                priceAnnual: "$290",
                 features: [
                     "✓ 3 Premium Items",
                     "✓ Free Shipping",
@@ -30,6 +36,7 @@ const t = {
             {
                 name: "Curator's Choice",
                 price: "$59",
+                priceAnnual: "$590",
                 features: [
                     "✓ 7 Premium Items",
                     "✓ Priority Shipping",
@@ -41,6 +48,7 @@ const t = {
             {
                 name: "Luxe Collection",
                 price: "$99",
+                priceAnnual: "$990",
                 features: [
                     "✓ 12+ Luxury Items",
                     "✓ Mystery Gifts",
@@ -49,21 +57,27 @@ const t = {
                 btn: "Select Luxe",
             },
         ],
-        perMo: "/mo",
     },
     "zh-tw": {
         tag: "每月精選",
         desc: "精選禮盒直送到府。選擇適合您生活方式的方案。",
+        monthly: "月付",
+        annual: "年付",
+        save: "省 2 個月",
+        perMo: "/月",
+        perYr: "/年",
         plans: [
             {
                 name: "入門禮盒",
                 price: "$29",
+                priceAnnual: "$290",
                 features: ["✓ 3 樣精選商品", "✓ 免運費", "✗ 客製化"],
                 btn: "選擇入門",
             },
             {
                 name: "策展人精選",
                 price: "$59",
+                priceAnnual: "$590",
                 features: ["✓ 7 樣精選商品", "✓ 優先配送", "✓ 完全客製化"],
                 btn: null,
                 tag: "超值首選",
@@ -71,21 +85,25 @@ const t = {
             {
                 name: "奢華系列",
                 price: "$99",
+                priceAnnual: "$990",
                 features: ["✓ 12+ 樣奢華商品", "✓ 神秘禮物", "✓ VIP 支援"],
                 btn: "選擇奢華",
             },
         ],
-        perMo: "/月",
     },
 }[lang] || {
     tag: "",
     desc: "",
-    plans: [
-        { name: "", price: "", features: [], btn: "" },
-        { name: "", price: "", features: [], btn: "", tag: "" },
-        { name: "", price: "", features: [], btn: "" },
-    ],
+    monthly: "",
+    annual: "",
+    save: "",
     perMo: "",
+    perYr: "",
+    plans: [
+        { name: "", price: "", priceAnnual: "", features: [], btn: "" },
+        { name: "", price: "", priceAnnual: "", features: [], btn: "", tag: "" },
+        { name: "", price: "", priceAnnual: "", features: [], btn: "" },
+    ],
 };
 ---
 
@@ -107,7 +125,36 @@ const t = {
 
     {
         contentFocus.showPlanComparison && (
-            <div class="max-w-5xl mx-auto grid md:grid-cols-3 gap-8 items-center">
+            <plan-toggle class="block max-w-5xl mx-auto">
+                {/* Billing period toggle */}
+                <div class="flex items-center justify-center gap-4 mb-10">
+                    <div class="inline-flex rounded-full bg-yellow-100 dark:bg-slate-800 p-1">
+                        <button
+                            type="button"
+                            data-billing="monthly"
+                            aria-pressed="true"
+                            class="px-5 py-2 rounded-full text-sm font-bold transition-colors"
+                        >
+                            {t.monthly}
+                        </button>
+                        <button
+                            type="button"
+                            data-billing="annual"
+                            aria-pressed="false"
+                            class="px-5 py-2 rounded-full text-sm font-bold transition-colors"
+                        >
+                            {t.annual}
+                        </button>
+                    </div>
+                    <span
+                        data-save
+                        class="hidden text-sm font-bold text-yellow-600 dark:text-yellow-400"
+                    >
+                        {t.save}
+                    </span>
+                </div>
+
+                <div class="grid md:grid-cols-3 gap-8 items-center">
                 {/* Basic Plan */}
                 <Card
                     variant="bordered"
@@ -117,8 +164,19 @@ const t = {
                         {t.plans[0].name}
                     </h3>
                     <div class="text-3xl font-bold my-4 text-gray-900 dark:text-white">
-                        {t.plans[0].price}
-                        <span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+                        <span
+                            data-price
+                            data-monthly={t.plans[0].price}
+                            data-annual={t.plans[0].priceAnnual}
+                        >
+                            {t.plans[0].price}
+                        </span>
+                        <span
+                            data-period
+                            data-monthly={t.perMo}
+                            data-annual={t.perYr}
+                            class="text-sm font-normal text-gray-500 dark:text-gray-400"
+                        >
                             {t.perMo}
                         </span>
                     </div>
@@ -154,8 +212,19 @@ const t = {
                         {t.plans[1].name}
                     </h3>
                     <div class="text-4xl font-bold my-4 text-gray-900 dark:text-white">
-                        {t.plans[1].price}
-                        <span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+                        <span
+                            data-price
+                            data-monthly={t.plans[1].price}
+                            data-annual={t.plans[1].priceAnnual}
+                        >
+                            {t.plans[1].price}
+                        </span>
+                        <span
+                            data-period
+                            data-monthly={t.perMo}
+                            data-annual={t.perYr}
+                            class="text-sm font-normal text-gray-500 dark:text-gray-400"
+                        >
                             {t.perMo}
                         </span>
                     </div>
@@ -184,8 +253,19 @@ const t = {
                         {t.plans[2].name}
                     </h3>
                     <div class="text-3xl font-bold my-4 text-gray-900 dark:text-white">
-                        {t.plans[2].price}
-                        <span class="text-sm font-normal text-gray-500 dark:text-gray-400">
+                        <span
+                            data-price
+                            data-monthly={t.plans[2].price}
+                            data-annual={t.plans[2].priceAnnual}
+                        >
+                            {t.plans[2].price}
+                        </span>
+                        <span
+                            data-period
+                            data-monthly={t.perMo}
+                            data-annual={t.perYr}
+                            class="text-sm font-normal text-gray-500 dark:text-gray-400"
+                        >
                             {t.perMo}
                         </span>
                     </div>
@@ -203,7 +283,56 @@ const t = {
                         {t.plans[2].btn}
                     </Button>
                 </Card>
-            </div>
+                </div>
+            </plan-toggle>
         )
     }
 </div>
+
+<script>
+    // 訂閱方案計費切換 Web Component:月付 / 年付。
+    // 各方案價格渲染在 data-monthly / data-annual 上,script 只讀 DOM。
+    class PlanToggle extends HTMLElement {
+        connectedCallback() {
+            const buttons =
+                this.querySelectorAll<HTMLButtonElement>("[data-billing]");
+            const prices = this.querySelectorAll<HTMLElement>("[data-price]");
+            const periods = this.querySelectorAll<HTMLElement>("[data-period]");
+            const save = this.querySelector<HTMLElement>("[data-save]");
+
+            const ACTIVE = ["bg-yellow-500", "text-white", "shadow"];
+            const INACTIVE = ["text-gray-600", "dark:text-gray-300"];
+
+            const apply = (mode: "monthly" | "annual") => {
+                buttons.forEach((b) => {
+                    const on = b.dataset.billing === mode;
+                    b.setAttribute("aria-pressed", String(on));
+                    b.classList.remove(...(on ? INACTIVE : ACTIVE));
+                    b.classList.add(...(on ? ACTIVE : INACTIVE));
+                });
+                prices.forEach((p) => {
+                    p.textContent = p.dataset[mode] ?? p.textContent;
+                });
+                periods.forEach((p) => {
+                    p.textContent = p.dataset[mode] ?? p.textContent;
+                });
+                save?.classList.toggle("hidden", mode !== "annual");
+            };
+
+            buttons.forEach((btn) => {
+                btn.addEventListener("click", () =>
+                    apply(
+                        (btn.dataset.billing as "monthly" | "annual") ??
+                            "monthly",
+                    ),
+                );
+            });
+
+            apply("monthly");
+        }
+    }
+
+    if (!customElements.get("plan-toggle")) {
+        customElements.define("plan-toggle", PlanToggle);
+    }
+</script>

--- a/src/components/domain/ecommerce/TechElectronicsLayout.astro
+++ b/src/components/domain/ecommerce/TechElectronicsLayout.astro
@@ -86,7 +86,28 @@ const t = {
             </div>
         </div>
 
-        <div class="grid md:grid-cols-2 gap-12">
+        <spec-tabs class="block">
+            {/* Model tabs */}
+            <div class="flex gap-2 mb-6">
+                <button
+                    type="button"
+                    data-model="pro"
+                    aria-pressed="true"
+                    class="px-4 py-1.5 rounded text-sm font-bold font-mono text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-slate-600 transition-colors"
+                >
+                    XG-9000
+                </button>
+                <button
+                    type="button"
+                    data-model="std"
+                    aria-pressed="false"
+                    class="px-4 py-1.5 rounded text-sm font-bold font-mono text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-slate-600 transition-colors"
+                >
+                    {t.colStd}
+                </button>
+            </div>
+
+            <div class="grid md:grid-cols-2 gap-12">
             <!-- Product Image & Specs -->
             <div>
                 <Card
@@ -107,18 +128,44 @@ const t = {
                                     {t.perf}
                                 </span>
                                 <div class="flex-grow bg-gray-200 dark:bg-slate-600 h-2 rounded-full overflow-hidden">
-                                    <div class="bg-cyan-500 h-full w-[90%]" />
+                                    <div
+                                        data-meter
+                                        data-pro="90"
+                                        data-std="55"
+                                        style="width:90%"
+                                        class="bg-cyan-500 h-full transition-all duration-500"
+                                    />
                                 </div>
-                                <span class="text-xs">90%</span>
+                                <span
+                                    data-pct
+                                    data-pro="90%"
+                                    data-std="55%"
+                                    class="text-xs w-10 text-right"
+                                >
+                                    90%
+                                </span>
                             </div>
                             <div class="flex items-center gap-2">
                                 <span class="w-24 text-xs font-bold">
                                     {t.batt}
                                 </span>
                                 <div class="flex-grow bg-gray-200 dark:bg-slate-600 h-2 rounded-full overflow-hidden">
-                                    <div class="bg-cyan-500 h-full w-[75%]" />
+                                    <div
+                                        data-meter
+                                        data-pro="75"
+                                        data-std="60"
+                                        style="width:75%"
+                                        class="bg-cyan-500 h-full transition-all duration-500"
+                                    />
                                 </div>
-                                <span class="text-xs">75%</span>
+                                <span
+                                    data-pct
+                                    data-pro="75%"
+                                    data-std="60%"
+                                    class="text-xs w-10 text-right"
+                                >
+                                    75%
+                                </span>
                             </div>
                         </div>
                     )
@@ -141,10 +188,12 @@ const t = {
                                     >{t.colFeature}</th
                                 >
                                 <th
+                                    data-col="pro"
                                     class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
                                     >XG-9000</th
                                 >
                                 <th
+                                    data-col="std"
                                     class="px-4 py-2 text-left text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider"
                                     >{t.colStd}</th
                                 >
@@ -159,10 +208,16 @@ const t = {
                                         <td class="px-4 py-2 font-medium text-gray-900 dark:text-gray-200">
                                             {row.feat}
                                         </td>
-                                        <td class="px-4 py-2 text-cyan-700 dark:text-cyan-400 font-bold">
+                                        <td
+                                            data-col="pro"
+                                            class="px-4 py-2 text-cyan-700 dark:text-cyan-400 font-bold"
+                                        >
                                             {row.val}
                                         </td>
-                                        <td class="px-4 py-2 text-gray-400 dark:text-gray-500">
+                                        <td
+                                            data-col="std"
+                                            class="px-4 py-2 text-gray-400 dark:text-gray-500"
+                                        >
                                             {row.std}
                                         </td>
                                     </tr>
@@ -172,6 +227,62 @@ const t = {
                     </table>
                 </div>
             </div>
-        </div>
+            </div>
+        </spec-tabs>
     </Card>
 </div>
+
+<script>
+    // 規格比較 tab Web Component:切換 XG-9000 / Standard,
+    // 高亮對應表格欄位並連動 meter bar。狀態存在 DOM 的 data-* 上。
+    class SpecTabs extends HTMLElement {
+        connectedCallback() {
+            const tabs = this.querySelectorAll<HTMLButtonElement>("[data-model]");
+            const cols = this.querySelectorAll<HTMLElement>("[data-col]");
+            const meters = this.querySelectorAll<HTMLElement>("[data-meter]");
+            const pcts = this.querySelectorAll<HTMLElement>("[data-pct]");
+
+            const TAB_ON = [
+                "bg-cyan-600",
+                "!text-white",
+                "border-cyan-600",
+            ];
+            const COL_ON = ["text-cyan-700", "dark:text-cyan-400", "font-bold"];
+            const COL_OFF = ["text-gray-400", "dark:text-gray-500"];
+
+            const apply = (model: string) => {
+                tabs.forEach((tab) => {
+                    const on = tab.dataset.model === model;
+                    tab.setAttribute("aria-pressed", String(on));
+                    on
+                        ? tab.classList.add(...TAB_ON)
+                        : tab.classList.remove(...TAB_ON);
+                });
+                cols.forEach((col) => {
+                    const on = col.dataset.col === model;
+                    col.classList.remove(...COL_ON, ...COL_OFF);
+                    col.classList.add(...(on ? COL_ON : COL_OFF));
+                });
+                meters.forEach((m) => {
+                    const v = m.dataset[model];
+                    if (v) m.style.width = `${v}%`;
+                });
+                pcts.forEach((p) => {
+                    if (p.dataset[model]) p.textContent = p.dataset[model]!;
+                });
+            };
+
+            tabs.forEach((tab) => {
+                tab.addEventListener("click", () =>
+                    apply(tab.dataset.model ?? "pro"),
+                );
+            });
+
+            apply("pro");
+        }
+    }
+
+    if (!customElements.get("spec-tabs")) {
+        customElements.define("spec-tabs", SpecTabs);
+    }
+</script>


### PR DESCRIPTION
## Summary

Fourth batch of the showcase interaction pass (`docs/specs/showcase-interaction-pass-spec.md`, added in #24): the 5 **ecommerce** category demo layouts each gain one signature native Web Component interaction. Interaction layer only — no content collection — with all state driven from DOM `data-*` so a future data-source swap is a template change leaving the JS untouched.

This batch adds two brand-new primitives — an **add-to-cart with live count + toast** and an **image gallery** — plus reuses of accordion / billing-toggle / tab-switch, for maximum variety across the 5.

## Interactions added

| Layout | Interaction | Element |
|---|---|---|
| `DigitalProductLayout` | Curriculum accordion — expand a module to see lessons | `<curriculum-accordion>` |
| `EditorialMagazineLayout` | Image gallery — click a thumbnail to swap the hero | `<image-gallery>` |
| `FoodGroceryLayout` | Add-to-cart — live count badge + toast | `<add-to-cart>` |
| `SubscriptionLandingLayout` | Monthly / annual billing toggle | `<plan-toggle>` |
| `TechElectronicsLayout` | Spec-comparison model tabs (drives column + meters) | `<spec-tabs>` |

All mirror the established pattern: hyphenated root wrapper, guarded `customElements.define` with a batch-unique tag name (no collision with the software/corporate batches), listeners bound in `connectedCallback` (re-bind across View Transitions; `add-to-cart` clears its toast timer in `disconnectedCallback`), accessible triggers (`aria-expanded`/`aria-pressed`, real `<button>`s).

Where an interaction needed more than one state's data, the mock `t` was enriched in **both** locales (curriculum modules/lessons, gallery image set, dual plan prices, per-model spec values) and rendered into the DOM as `data-*` — never read from the JS object at runtime.

## Acceptance criteria (spec §6)

- [x] `npm run build` green; `astro check` 0 errors (only pre-existing hints)
- [x] All 5 interactions work in both locales across all 10 routes
- [x] Every interaction survives a View Transition (verified: SPA-nav to another ecommerce theme, interaction still responds)
- [x] Zero interaction state read from the JS `t` object — all read from DOM `data-*`
- [x] No hardcoded counts/categories in JS (cart count accumulated from clicks)
- [x] `package.json` untouched — zero new runtime frameworks
- [x] Conventional Commits, one `feat(ecommerce)` commit per layout

## Test plan

- `npm run dev`, visit `/{en,zh-tw}/explore/ecommerce/{DigitalProducts,FashionLuxury,FoodGrocery,SubscriptionBox,TechElectronics}`
- Expand curriculum modules, swap gallery thumbnails, add products to cart (watch the badge + toast), toggle monthly/annual, switch spec models
- Navigate away via ThemeDock and back — every interaction must still respond

Automated end-to-end verification (headless Edge) drove all 5 interactions + the View-Transition-survival case: **12/12 assertions pass**; a separate zh-tw smoke run confirms hydration and content parity across all 5 zh-tw routes.

## Scope note

This is the last of the 4 non-portfolio batches. With portfolio (#17, merged), software (#24), corporate (#25), and this, all 5 theme categories now have working interactions. The shared spec lives in #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
